### PR TITLE
Fix: Skipping duplicate downloads can unbalance licenses.

### DIFF
--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -166,7 +166,7 @@ class PreparePartitionTest(unittest.TestCase):
     def setUp(self) -> None:
         self.dummy_manifest = MockManifest(Location('mock://dummy'))
 
-    def create_partition_configs(self, config, store: t.Optional[Store] = None):
+    def create_partition_configs(self, config, store: t.Optional[Store] = None) -> t.List[t.Dict]:
         partition_list = prepare_partitions(config, store=store)
         return [
             assemble_partition_config(p, config, manifest=self.dummy_manifest)
@@ -312,7 +312,6 @@ class PreparePartitionTest(unittest.TestCase):
         research_configs = [cfg for cfg in actual if cfg and cfg['parameters']['api_url'].endswith('1')]
         cloud_configs = [cfg for cfg in actual if cfg and cfg['parameters']['api_url'].endswith('2')]
 
-        print(len(research_configs), len(cloud_configs))
         self.assertEqual(len(research_configs), len(cloud_configs))
 
 


### PR DESCRIPTION
I found a subtle bug over the weekend: Skipping already-downloaded files will cause MARS queues to be exhausted. The distribution of licenses was calculated before skips were taken into account. When workers pulled in new work up to the license limit, it would sometimes pull in more than the limit for that license. 

Workaround: Use the `-n` flag to configure far fewer workers than the MARS limit allows (<< 20).

In this CL, I've introduced a test to check if skips will unbalance licenses. Then, I have a fix that passes the test. 

This fix ensures correctness while getting closer to the max limit for concurrent downloads.