### PR TITLE
`weather-mv`: Now using Streaming Inserts into BQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ _Steps_:
    ```shell
    weather-mv --uris "./local_run/**.nc" \ # or  --uris "./split_data/**.nc" \
       --output_table "$PROJECT.$DATASET_ID.$TABLE_ID" \
-      --temp_location gs://$BUCKET/tmp/
       --direct_num_workers 2
    ```
 

--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -14,7 +14,7 @@ Weather Mover loads weather data from cloud storage into [Google BigQuery](https
 ## Usage
 
 ```
-usage: weather-mv [-h] [-v variables [variables ...]] [-a area [area ...]] -i URIS -o OUTPUT_TABLE -t TEMP_LOCATION [--import_time IMPORT_TIME] [--infer_schema]
+usage: weather-mv [-h] [-v variables [variables ...]] [-a area [area ...]] -i URIS -o OUTPUT_TABLE [--import_time IMPORT_TIME] [--infer_schema] [-d]
 
 Weather Mover loads weather data from cloud storage into Google BigQuery.
 ```
@@ -23,7 +23,6 @@ _Common options_:
 
 * `-i, --uris`: (required) URI prefix matching input netcdf objects. Ex: gs://ecmwf/era5/era5-2015-""
 * `-o, --output_table`: (required) Full name of destination BigQuery table. Ex: my_project.my_dataset.my_table
-* `-t, --temp_location`: Temp Location for staging files to import to BigQuery
 * `--import_time`: When writing data to BigQuery, record that data import occurred at this time
   (format: YYYY-MM-DD HH:MM:SS.usec+offset). Default: now in UTC.
 * `-v, --variables`:  Target variables for the BigQuery schema. Default: will import all data variables as columns.
@@ -32,12 +31,13 @@ _Common options_:
 
 Invoke with `-h` or `--help` to see the full range of options.
 
+> Warning: Dry-runs are currently not supported. See [#22](https://github.com/googlestaging/weather-tools/issues/22).
+
 _Usage Examples_:
 
 ```bash
 weather-mv --uris "gs://your-bucket/*.nc" \
            --output_table $PROJECT.$DATASET_ID.$TABLE_ID \
-           --temp_location gs://$BUCKET/tmp \
            --direct_num_workers 2
 ```
 
@@ -47,7 +47,6 @@ Upload only a subset of variables:
 weather-mv --uris "gs://your-bucket/*.nc" \
            --output_table $PROJECT.$DATASET_ID.$TABLE_ID \
            --variables u10 v10 t
-           --temp_location gs://$BUCKET/tmp \
            --direct_num_workers 2
 ```
 
@@ -57,7 +56,6 @@ Upload all variables, but for a specific geographic region (for example, the con
 weather-mv --uris "gs://your-bucket/*.nc" \
            --output_table $PROJECT.$DATASET_ID.$TABLE_ID \
            --area 49.34 -124.68 24.74 -66.95 \
-           --temp_location gs://$BUCKET/tmp \
            --direct_num_workers 2
 ```
 

--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -11,6 +11,9 @@ Weather Mover loads weather data from cloud storage into [Google BigQuery](https
 * **Parallel Upload**: Each file will be processed in parallel. With Dataflow autoscaling, even large datasets can be
   processed in a reasonable amount of time.
 
+> Note: Data is written into BigQuery using streaming inserts. It may take [up to 90 minutes](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataavailability)
+> for buffers to persist into storage. However, weather data will be available for querying immediately.
+
 ## Usage
 
 ```


### PR DESCRIPTION
- This lets us remove the `temp_location` argument
- Data should be written sooner into BQ (default batch size is 500 rows).
- Documentation has been updated as well.

TODO
- [x] Test new pipeline e2e