### PR TITLE
weather-splitter: allow for more flexible output files

### DIFF
--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -19,7 +19,10 @@ Split weather data file into files by variable.
 _Common options_:
 
 * `-i, --input-pattern`: Pattern for input weather data.
-* `-o, --output-template`: Path to base folder for output files, or template using Python formating, see [Output section](#output) below.
+* `--output-template`: Path to template using Python formatting, 
+                       see [Output section](#output) below. Mutually exclusive with `--output-dir`.
+* `--output-dir`: Path to base folder for output files, see [Output section](#output) below.
+                  Mutually exclusive with `--output-template`
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
 
 Invoke with `-h` or `--help` to see the full range of options.
@@ -73,11 +76,11 @@ On the other hand, to specify a specific pattern use
 
 ## Output
 
-The base output file names are specified using the `--output-template` flag. This template can be either a directory,
-or contain Python-style numbered formating.
+The base output file names are specified using the `--output-template` or `--output-dir` flags. 
+These flags are mutually exclusive, and one of them is required.
 
-### Output template is a directory
-Based on the output template path, the directory structure of the
+### Output directory
+Based on the output directory path, the directory structure of the
 input pattern is replicated.
 
 To create the directory structure, the common path of the input pattern is removed from the input file path and replaced
@@ -87,29 +90,29 @@ Example:
 
 ```bash
 --input-pattern 'gs://test-input/era5/2020/**' \
---output-template 'gs://test-output/splits'
+--output-dir 'gs://test-output/splits'
 ```
 
 For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
 `gs://test-output/splits/2020/02/01_` and if the temperature is a variable in that data, the output file for that
 split will be `gs://test-output/splits/2020/02/01_t.nc`
 
-### Output template with Python-style formating
+### Output template with Python-style formatting
 Using Python-style substitution (e.g. `{1}`) allows for more flexibility when creating the output files.
 The substitutions are based on the directory structure of the input file, where each `{<x>}` stands for
 one directory name, counting backwards from the end, i.e. the file name is `{0}`, the immediate
-directory in which it is located is `{1}`.
+directory in which it is located is `{1}`, and so on.
 
 Example:
 
 ```bash
 --input-pattern 'gs://test-input/era5/2020/**' \
---output-template 'gs://test-output/splits/{2}.{1}.{0}T00.'
+--output-template 'gs://test-output/splits/{2}.{0}.{1}T00.'
 ```
 
 For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
-`gs://test-output/splits/2020.02.01T00.` and if the temperature is a variable in that data, the output file for that
-split will be `gs://test-output/splits/2020/01/01.t.nc`
+`gs://test-output/splits/2020.01.02T00.` and if the temperature is a variable in that data, the output file for that
+split will be `gs://test-output/splits/2020/01/02T00.t.nc`
 
 Note that in this case no '_' is added, the template is used as is.
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -19,9 +19,7 @@ Split weather data file into files by variable.
 _Common options_:
 
 * `-i, --input-pattern`: Pattern for input weather data.
-* `-o, --output-dir`: Path to base folder for output files. This directory will replace the common path of the
-  input-pattern. For `input-pattern a/b/c/**` and
-  `output-dir /x/y/z` a file `a/b/c/file.nc` will createoutput files like `/x/y/z/c/file.nc_shortname.nc`
+* `-o, --output-template`: Path to base folder for output files, or template using Python formating, see [Output section](#output) below.
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
 
 Invoke with `-h` or `--help` to see the full range of options.
@@ -75,22 +73,45 @@ On the other hand, to specify a specific pattern use
 
 ## Output
 
-The base output path is specified using the `--output-path` flag. Based on that path, the directory structure of the
+The base output file names are specified using the `--output-template` flag. This template can be either a directory,
+or contain Python-style numbered formating.
+
+### Output template is a directory
+Based on the output template path, the directory structure of the
 input pattern is replicated.
 
 To create the directory structure, the common path of the input pattern is removed from the input file path and replaced
-with the output path.
+with the output path. A '_' is added to separate the split level / variable.
 
 Example:
 
 ```bash
 --input-pattern 'gs://test-input/era5/2020/**' \
---output-dir 'gs://test-output/splits'
+--output-template 'gs://test-output/splits'
 ```
 
-For a file `gs://test-input/era5/2020/01/01.nc` the output file pattern is
-`gs://test-output/splits/2020/01/01.nc` and if the temperature is a variable in that data, the output file for that
-split will be `gs://test-output/splits/2020/01/01.nc_t.nc`
+For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
+`gs://test-output/splits/2020/02/01_` and if the temperature is a variable in that data, the output file for that
+split will be `gs://test-output/splits/2020/02/01_t.nc`
+
+### Output template with Python-style formating
+Using Python-style substitution (e.g. `{1}`) allows for more flexibility when creating the output files.
+The substitutions are based on the directory structure of the input file, where each `{<x>}` stands for
+one directory name, counting backwards from the end, i.e. the file name is `{0}`, the immediate
+directory in which it is located is `{1}`.
+
+Example:
+
+```bash
+--input-pattern 'gs://test-input/era5/2020/**' \
+--output-template 'gs://test-output/splits/{2}.{1}.{0}T00.'
+```
+
+For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
+`gs://test-output/splits/2020.02.01T00.` and if the temperature is a variable in that data, the output file for that
+split will be `gs://test-output/splits/2020/01/01.t.nc`
+
+Note that in this case no '_' is added, the template is used as is.
 
 ## Dry run
 

--- a/weather_sp/splitter_pipeline/file_name_utils.py
+++ b/weather_sp/splitter_pipeline/file_name_utils.py
@@ -29,7 +29,7 @@ def get_output_file_base_name(filename: str, out_pattern: str, input_base_dir: s
     Args:
         filename: input file to be split
         out_pattern: pattern to apply when creating output file
-        input_base_dir: used if out_pattern does not contain any '*' wildcards.
+        input_base_dir: used if out_pattern does not contain any '{}' substitutions.
             The output file is then created by replacing this part of the input name
             with the output pattern.
     '''

--- a/weather_sp/splitter_pipeline/file_name_utils.py
+++ b/weather_sp/splitter_pipeline/file_name_utils.py
@@ -16,7 +16,8 @@ import logging
 import os
 import typing as t
 
-_WEATHER_FILE_ENDINGS = ('.nc', '.cd', '.grib', '.grb', '.grb2', '.grib2')
+GRIB_FILE_ENDINGS = ('.grib', '.grb', '.grb2', '.grib2', '.gb')
+NETCDF_FILE_ENDINGS = ('.nc', '.cd')
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +34,7 @@ def get_output_file_base_name(filename: str,
                               out_pattern: t.Optional[str],
                               out_dir: t.Optional[str],
                               input_base_dir: str) -> OutFileInfo:
-    """
-    Construct the base output file name by applying the out_pattern to the
+    """Construct the base output file name by applying the out_pattern to the
     filename.
 
     Example:
@@ -53,7 +53,7 @@ def get_output_file_base_name(filename: str,
     """
     file_ending = ''
     split_name, ending = os.path.splitext(filename)
-    if ending in _WEATHER_FILE_ENDINGS:
+    if ending in [*GRIB_FILE_ENDINGS, *NETCDF_FILE_ENDINGS]:
         file_ending = ending
         filename = split_name
 

--- a/weather_sp/splitter_pipeline/file_name_utils.py
+++ b/weather_sp/splitter_pipeline/file_name_utils.py
@@ -1,0 +1,49 @@
+import logging
+import os
+import typing as t
+
+_WEATHER_FILE_ENDINGS = ('.nc', '.cd', '.grib', '.grb', '.grb2', '.grib2')
+
+logger = logging.getLogger(__name__)
+
+
+class OutFileInfo(t.NamedTuple):
+    file_name_base: str
+    ending: str
+
+    def __str__(self):
+        return f'{self.file_name_base}/*/{self.ending}'
+
+
+def get_output_file_base_name(filename: str, out_pattern: str, input_base_dir: str) -> OutFileInfo:
+    '''
+    Construct the base output file name by applying the out_pattern to the
+    filename.
+
+    Example:
+        filename = 'gs://my_bucket/data_to_split/2020/01/21.nc'
+        out_pattern = 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.'
+        resulting output base = 'gs://my_bucket/splits/2020-01-21_old_data.'
+        resulting file ending = '.nc'
+
+    Args:
+        filename: input file to be split
+        out_pattern: pattern to apply when creating output file
+        input_base_dir: used if out_pattern does not contain any '*' wildcards.
+            The output file is then created by replacing this part of the input name
+            with the output pattern.
+    '''
+    file_ending = ''
+    for ending in _WEATHER_FILE_ENDINGS:
+        if filename.endswith(ending):
+            file_ending = ending
+            filename = filename[:-len(ending)]
+            break
+    if '{' not in out_pattern:
+        return OutFileInfo(f'{filename.replace(input_base_dir, out_pattern)}_', file_ending)
+    in_sections = []
+    path = filename
+    while path:
+        path, tail = os.path.split(path)
+        in_sections.append(tail)
+    return OutFileInfo(out_pattern.format(*in_sections), file_ending)

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from .file_name_utils import get_output_file_base_name
@@ -8,13 +22,15 @@ class FileNameUtilsTest(unittest.TestCase):
     def test_get_output_file_base_name_format(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
                                              out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             out_dir=None,
                                              input_base_dir='ignored')
         self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020-01-21_old_data.')
         self.assertEqual(out_info.ending, '.nc')
 
     def test_get_output_file_base_name_replace(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_pattern='gs://my_bucket/splits/',
+                                             out_pattern=None,
+                                             out_dir='gs://my_bucket/splits/',
                                              input_base_dir='gs://my_bucket/data_to_split/')
         self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020/01/21_')
         self.assertEqual(out_info.ending, '.nc')
@@ -22,6 +38,7 @@ class FileNameUtilsTest(unittest.TestCase):
     def test_get_output_file_base_name_format_no_fileending(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21',
                                              out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             out_dir=None,
                                              input_base_dir='ignored')
         self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020-01-21_old_data.')
         self.assertEqual(out_info.ending, '')
@@ -29,6 +46,7 @@ class FileNameUtilsTest(unittest.TestCase):
     def test_get_output_file_base_name_format_filecontainsdots(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
                                              out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             out_dir=None,
                                              input_base_dir='ignored')
         self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020-01-21.T00z.stuff_old_data.')
         self.assertEqual(out_info.ending, '')

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -1,0 +1,34 @@
+import unittest
+
+from .file_name_utils import get_output_file_base_name
+
+
+class FileNameUtilsTest(unittest.TestCase):
+
+    def test_get_output_file_base_name_format(self):
+        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             input_base_dir='ignored')
+        self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020-01-21_old_data.')
+        self.assertEqual(out_info.ending, '.nc')
+
+    def test_get_output_file_base_name_replace(self):
+        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                             out_pattern='gs://my_bucket/splits/',
+                                             input_base_dir='gs://my_bucket/data_to_split/')
+        self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020/01/21_')
+        self.assertEqual(out_info.ending, '.nc')
+
+    def test_get_output_file_base_name_format_no_fileending(self):
+        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21',
+                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             input_base_dir='ignored')
+        self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020-01-21_old_data.')
+        self.assertEqual(out_info.ending, '')
+
+    def test_get_output_file_base_name_format_filecontainsdots(self):
+        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
+                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             input_base_dir='ignored')
+        self.assertEqual(out_info.file_name_base, 'gs://my_bucket/splits/2020-01-21.T00z.stuff_old_data.')
+        self.assertEqual(out_info.ending, '')

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -23,7 +23,7 @@ import typing as t
 from apache_beam.io.filesystems import FileSystems
 from contextlib import contextmanager
 
-from .file_name_utils import OutFileInfo
+from .file_name_utils import OutFileInfo, GRIB_FILE_ENDINGS, NETCDF_FILE_ENDINGS
 
 logger = logging.getLogger(__name__)
 
@@ -160,12 +160,12 @@ class DrySplitter(FileSplitter):
 
 def get_splitter(file_path: str, output_info: OutFileInfo,
                  dry_run: bool) -> FileSplitter:
-    if output_info.ending in ('.nc', '.cd'):
+    if output_info.ending in NETCDF_FILE_ENDINGS:
         metrics.Metrics.counter('get_splitter', 'netcdf').inc()
         if dry_run:
             return DrySplitter(file_path, output_info)
         return NetCdfSplitter(file_path, output_info)
-    if output_info.ending in ('grb', 'grib', 'grib2', 'grb2'):
+    if output_info.ending in GRIB_FILE_ENDINGS:
         metrics.Metrics.counter('get_splitter', 'grib').inc()
     else:
         logger.info('unspecified file type, assuming grib for %s', file_path)

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -23,6 +23,8 @@ import typing as t
 from apache_beam.io.filesystems import FileSystems
 from contextlib import contextmanager
 
+from .file_name_utils import OutFileInfo
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,15 +41,14 @@ class SplitKey(t.NamedTuple):
 class FileSplitter(abc.ABC):
     """Base class for weather file splitters."""
 
-    def __init__(self, input_path: str, output_path: str, file_suffix: str = "",
+    def __init__(self, input_path: str, output_info: OutFileInfo,
                  level: int = logging.INFO):
         self.input_path = input_path
-        self.output_path = output_path
-        self.file_suffix = file_suffix
+        self.output_info = output_info
         self.logger = logging.getLogger(f'{__name__}.{type(self).__name__}')
         self.logger.setLevel(level)
         self.logger.debug('Splitter for path=%s, output base=%s',
-                          self.input_path, self.output_path)
+                          self.input_path, self.output_info)
 
     @abc.abstractmethod
     def split_data(self) -> None:
@@ -66,16 +67,16 @@ class FileSplitter(abc.ABC):
             shutil.copyfileobj(src_file, dest_file)
 
     def _get_output_file_path(self, key: SplitKey) -> str:
-        level = '_{level}'.format(level=key.level) if key.level else ''
-        return '{base}{level}_{sn}.{ending}'.format(
-            base=self.output_path, level=level, sn=key.short_name,
-            ending=self.file_suffix)
+        level = '{level}_'.format(level=key.level) if key.level else ''
+        return '{base}{level}{sn}{ending}'.format(
+            base=self.output_info.file_name_base, level=level, sn=key.short_name,
+            ending=self.output_info.ending)
 
 
 class GribSplitter(FileSplitter):
 
-    def __init__(self, input_path: str, output_folder: str):
-        super().__init__(input_path, output_folder, file_suffix='grib')
+    def __init__(self, input_path: str, output_info: OutFileInfo):
+        super().__init__(input_path, output_info)
 
     def split_data(self) -> None:
         outputs = dict()
@@ -105,8 +106,8 @@ class GribSplitter(FileSplitter):
 
 class NetCdfSplitter(FileSplitter):
 
-    def __init__(self, input_path: str, output_folder: str):
-        super().__init__(input_path, output_folder, file_suffix='nc')
+    def __init__(self, input_path: str, output_info: OutFileInfo):
+        super().__init__(input_path, output_info)
 
     def split_data(self) -> None:
         with self._open_dataset_locally() as nc_data:
@@ -149,28 +150,27 @@ class NetCdfSplitter(FileSplitter):
 
 
 class DrySplitter(FileSplitter):
-    def __init__(self, file_path: str, output_path: str, file_ending: str):
-        super().__init__(file_path, output_path, file_ending)
+    def __init__(self, file_path: str, output_info: OutFileInfo):
+        super().__init__(file_path, output_info)
 
     def split_data(self) -> None:
-        self.logger.info('input file: %s - output scheme: %s_level_shortname.%s',
-                         self.input_path, self.output_path, self.file_suffix)
+        self.logger.info('input file: %s - output scheme: %s',
+                         self.input_path, self._get_output_file_path(SplitKey('level', 'shortname')))
 
 
-def get_splitter(file_path: str, output_path: str,
+def get_splitter(file_path: str, output_info: OutFileInfo,
                  dry_run: bool) -> FileSplitter:
-    if file_path.endswith('.nc') or file_path.endswith('.cd'):
+    if output_info.ending in ('.nc', '.cd'):
         metrics.Metrics.counter('get_splitter', 'netcdf').inc()
         if dry_run:
-            return DrySplitter(file_path, output_path, "nc")
-        return NetCdfSplitter(file_path, output_path)
-    if file_path.endswith('grb') or file_path.endswith(
-            'grib') or file_path.endswith('grib2'):
+            return DrySplitter(file_path, output_info)
+        return NetCdfSplitter(file_path, output_info)
+    if output_info.ending in ('grb', 'grib', 'grib2', 'grb2'):
         metrics.Metrics.counter('get_splitter', 'grib').inc()
     else:
         logger.info('unspecified file type, assuming grib for %s', file_path)
         metrics.Metrics.counter('get_splitter',
                                 'unidentified grib').inc()
     if dry_run:
-        return DrySplitter(file_path, output_path, "grib")
-    return GribSplitter(file_path, output_path)
+        return DrySplitter(file_path, output_info)
+    return GribSplitter(file_path, output_info)

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 from unittest.mock import patch
 
 import weather_sp
+from .file_name_utils import OutFileInfo
 from .file_splitters import DrySplitter
 from .file_splitters import GribSplitter
 from .file_splitters import NetCdfSplitter
@@ -32,22 +33,22 @@ from .file_splitters import get_splitter
 class GetSplitterTest(unittest.TestCase):
 
     def test_get_splitter_grib(self):
-        splitter = get_splitter('some/file/path/data.grib', 'some_out',
+        splitter = get_splitter('some/file/path/data.grib', OutFileInfo(file_name_base='some_out', ending='.grib'),
                                 dry_run=False)
         self.assertIsInstance(splitter, GribSplitter)
 
     def test_get_splitter_nc(self):
-        splitter = get_splitter('some/file/path/data.nc', 'some_out',
+        splitter = get_splitter('some/file/path/data.nc', OutFileInfo(file_name_base='some_out', ending='.nc'),
                                 dry_run=False)
         self.assertIsInstance(splitter, NetCdfSplitter)
 
     def test_get_splitter_undetermined(self):
-        splitter = get_splitter('some/file/path/data', 'some_out',
+        splitter = get_splitter('some/file/path/data', OutFileInfo(file_name_base='some_out', ending=''),
                                 dry_run=False)
         self.assertIsInstance(splitter, GribSplitter)
 
     def test_get_splitter_dryrun(self):
-        splitter = get_splitter('some/file/path/data.grib', 'some_out',
+        splitter = get_splitter('some/file/path/data.grib', OutFileInfo(file_name_base='some_out', ending='.grib'),
                                 dry_run=True)
         self.assertIsInstance(splitter, DrySplitter)
 
@@ -63,20 +64,20 @@ class GribSplitterTest(unittest.TestCase):
             shutil.rmtree(split_dir)
 
     def test_get_output_file_path(self):
-        splitter = GribSplitter('path/to/input', 'path/output/file')
+        splitter = GribSplitter('path/to/input', OutFileInfo(file_name_base='path/output/file_', ending='.grib'))
         out = splitter._get_output_file_path(SplitKey('level', 'cc'))
         self.assertEqual(out, 'path/output/file_level_cc.grib')
 
     @patch('apache_beam.io.filesystems.FileSystems.create')
     def test_open_outfile(self, mock_io):
-        splitter = GribSplitter('path/to/input', 'path/output/file')
+        splitter = GribSplitter('path/to/input', OutFileInfo(file_name_base='path/output/file_', ending='.grib'))
         splitter._open_outfile(SplitKey('level', 'cc'))
         mock_io.assert_called_with('path/output/file_level_cc.grib')
 
     def test_split_data(self):
         input_path = f'{self._data_dir}/era5_sample.grib'
         splitter = GribSplitter(input_path,
-                                f'{self._data_dir}/split_files/era5_sample.grib')
+                                OutFileInfo(f'{self._data_dir}/split_files/era5_sample_', '.grib'))
         splitter.split_data()
         self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
 
@@ -89,7 +90,7 @@ class GribSplitterTest(unittest.TestCase):
             input_data[grb.shortName].append(grb.values)
 
         for sn in short_names:
-            split_file = f'{self._data_dir}/split_files/era5_sample.grib_isobaricInhPa_{sn}.grib'
+            split_file = f'{self._data_dir}/split_files/era5_sample_isobaricInhPa_{sn}.grib'
             split_grbs = pygrib.open(split_file)
             for grb in split_grbs:
                 split_data[sn].append(grb.values)
@@ -112,19 +113,19 @@ class NetCdfSplitterTest(unittest.TestCase):
             shutil.rmtree(split_dir)
 
     def test_get_output_file_path(self):
-        splitter = NetCdfSplitter('path/to/input', 'path/output/file')
+        splitter = NetCdfSplitter('path/to/input', OutFileInfo('path/output/file_', '.nc'))
         out = splitter._get_output_file_path(SplitKey('', 'cc'))
         self.assertEqual(out, 'path/output/file_cc.nc')
 
     def test_split_data(self):
         input_path = f'{self._data_dir}/era5_sample.nc'
         splitter = NetCdfSplitter(input_path,
-                                  f'{self._data_dir}/split_files/era5_sample.nc')
+                                  OutFileInfo(f'{self._data_dir}/split_files/era5_sample_', '.nc'))
         splitter.split_data()
         self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
         input_data = xr.open_dataset(input_path, engine='netcdf4')
         for sn in ['d', 'cc', 'z']:
-            split_file = f'{self._data_dir}/split_files/era5_sample.nc_{sn}.nc'
+            split_file = f'{self._data_dir}/split_files/era5_sample_{sn}.nc'
             split_data = xr.open_dataset(split_file, engine='netcdf4')
             xr.testing.assert_allclose(input_data[sn], split_data[sn])
 

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -35,13 +35,18 @@ def configure_logger(verbosity: int) -> None:
     logger.setLevel(level)
 
 
-def split_file(input_file: str, input_base_dir: str, output_template: str, dry_run: bool):
+def split_file(input_file: str,
+               input_base_dir: str,
+               output_template: t.Optional[str],
+               output_dir: t.Optional[str],
+               dry_run: bool):
     logger.info('Splitting file %s', input_file)
     metrics.Metrics.counter('pipeline', 'splitting file').inc()
     splitter = get_splitter(input_file,
                             get_output_base_name(input_path=input_file,
                                                  input_base=input_base_dir,
-                                                 output_template=output_template),
+                                                 output_template=output_template,
+                                                 output_dir=output_dir),
                             dry_run)
     splitter.split_data()
 
@@ -54,9 +59,11 @@ def _get_base_input_directory(input_pattern: str) -> str:
     return os.path.dirname(os.path.dirname(base_dir))
 
 
-def get_output_base_name(input_path: str, input_base: str,
-                         output_template: str) -> OutFileInfo:
-    return get_output_file_base_name(input_path, output_template, input_base)
+def get_output_base_name(input_path: str,
+                         input_base: str,
+                         output_template: t.Optional[str],
+                         output_dir: t.Optional[str]) -> OutFileInfo:
+    return get_output_file_base_name(input_path, output_template, output_dir, input_base)
 
 
 def run(argv: t.List[str], save_main_session: bool = True):
@@ -67,16 +74,24 @@ def run(argv: t.List[str], save_main_session: bool = True):
     )
     parser.add_argument('-i', '--input-pattern', type=str, required=True,
                         help='Pattern for input weather data.')
-    parser.add_argument('-o', '--output-template', type=str, required=True,
-                        help='Template specifying path to output files. '
-                             'Either a directory that will replace the common path of the '
-                             'input_pattern, or a template using python-style formatting substitution'
-                             'of input directory names.'
-                             'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`,'
-                             '`output_template /x/y/z` will create'
-                             'output files like `/x/y/z/c/file_shortname.nc`, while a template'
-                             'with formating `/somewhere/{1}-{0}.` will give `somewhere/c-file.shortname.nc`'
-                        )
+    output_options = parser.add_mutually_exclusive_group(required=True)
+    output_options.add_argument(
+            '--output-template', type=str,
+            help='Template specifying path to output files using '
+                 'python-style formatting substitution of input '
+                 'directory names. '
+                 'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, '
+                 'a template with formatting `/somewhere/{1}-{0}.` '
+                 'will give `somewhere/c-file.shortname.nc`'
+                 )
+    output_options.add_argument(
+            '--output-dir', type=str,
+            help='Output directory that will replace the common path of the '
+                 'input_pattern. '
+                 'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, '
+                 '`output_template /x/y/z` will create '
+                 'output files like `/x/y/z/c/file_shortname.nc`'
+                 )
     parser.add_argument('-d', '--dry-run', action='store_true', default=False,
                         help='Test the input file matching and the output file scheme without splitting.')
     known_args, pipeline_args = parser.parse_known_args(argv[1:])
@@ -87,15 +102,18 @@ def run(argv: t.List[str], save_main_session: bool = True):
     pipeline_options.view_as(SetupOptions).save_main_session = save_main_session
     input_pattern = known_args.input_pattern
     input_base_dir = _get_base_input_directory(input_pattern)
-    # output target directory, if empty, set to same as input
     output_template = known_args.output_template
-    if not output_template:
-        output_template = input_base_dir
+    output_dir = known_args.output_dir
+    if not output_template and not output_dir:
+        raise ValueError('No output specified')
     dry_run = known_args.dry_run
 
     logger.debug('input_pattern: %s', input_pattern)
     logger.debug('input_base_dir: %s', input_base_dir)
-    logger.debug('output_template: %s', output_template)
+    if output_template:
+        logger.debug('output_template: %s', output_template)
+    if output_dir:
+        logger.debug('output_dir: %s', output_dir)
     logger.debug('dry_run: %s', known_args.dry_run)
     with beam.Pipeline(options=pipeline_options) as p:
         (
@@ -107,5 +125,6 @@ def run(argv: t.List[str], save_main_session: bool = True):
                 | 'SplitFiles' >> beam.Map(split_file,
                                            input_base_dir,
                                            output_template,
+                                           output_dir,
                                            dry_run)
         )

--- a/weather_sp/splitter_pipeline/pipeline_test.py
+++ b/weather_sp/splitter_pipeline/pipeline_test.py
@@ -15,6 +15,7 @@
 import unittest
 from unittest.mock import patch
 
+from .file_name_utils import OutFileInfo
 from .pipeline import _get_base_input_directory
 from .pipeline import get_output_base_name
 from .pipeline import split_file
@@ -38,14 +39,14 @@ class PipelineTest(unittest.TestCase):
 
     def test_get_output_base_name(self):
         self.assertEqual(get_output_base_name('somewhere/somefile',
-                                              'somewhere', 'out/there'),
-                         'out/there/somefile')
+                                              'somewhere', 'out/there').file_name_base,
+                         'out/there/somefile_')
 
     @patch('weather_sp.splitter_pipeline.pipeline.get_splitter')
     def test_split_file(self, mock_get_splitter):
         split_file('somewhere/somefile', 'somewhere', 'out/there', dry_run=True)
         mock_get_splitter.assert_called_with('somewhere/somefile',
-                                             'out/there/somefile',
+                                             OutFileInfo('out/there/somefile_', ''),
                                              True)
 
 

--- a/weather_sp/splitter_pipeline/pipeline_test.py
+++ b/weather_sp/splitter_pipeline/pipeline_test.py
@@ -38,13 +38,19 @@ class PipelineTest(unittest.TestCase):
                 '/path/to/some')
 
     def test_get_output_base_name(self):
-        self.assertEqual(get_output_base_name('somewhere/somefile',
-                                              'somewhere', 'out/there').file_name_base,
-                         'out/there/somefile_')
+        self.assertEqual(get_output_base_name(
+                input_path='somewhere/somefile',
+                input_base='somewhere',
+                output_template=None,
+                output_dir='out/there').file_name_base, 'out/there/somefile_')
 
     @patch('weather_sp.splitter_pipeline.pipeline.get_splitter')
     def test_split_file(self, mock_get_splitter):
-        split_file('somewhere/somefile', 'somewhere', 'out/there', dry_run=True)
+        split_file(input_file='somewhere/somefile',
+                   input_base_dir='somewhere',
+                   output_dir='out/there',
+                   output_template=None,
+                   dry_run=True)
         mock_get_splitter.assert_called_with('somewhere/somefile',
                                              OutFileInfo('out/there/somefile_', ''),
                                              True)


### PR DESCRIPTION
Use python-style formatting for more flexible output files when splitting files in a directory hierarchy.