### PR TITLE
Updated the standard example configs to use Reanalyses instead of Ensemble Means.

### DIFF
--- a/configs/era5_example_config.cfg
+++ b/configs/era5_example_config.cfg
@@ -21,7 +21,7 @@ partition_keys=
     day
     pressure_level
 [selection]
-product_type=ensemble_mean
+product_type=reanalysis
 format=netcdf
 variable=
     divergence

--- a/configs/era5_example_config_local_run.cfg
+++ b/configs/era5_example_config_local_run.cfg
@@ -29,7 +29,7 @@ partition_keys=
     day
     pressure_level
 [selection]
-product_type=ensemble_mean
+product_type=reanalysis
 format=netcdf
 variable=
     divergence

--- a/configs/era5_example_config_preproc.cfg
+++ b/configs/era5_example_config_preproc.cfg
@@ -20,7 +20,8 @@ partition_keys=
     month
     day
 [selection]
-product_type=reanalysis
+# These are the averages of an ensemble of analyses.
+product_type=ensemble_mean
 format=grib
 grid=o1280
 variable=

--- a/configs/era5_example_config_preproc.cfg
+++ b/configs/era5_example_config_preproc.cfg
@@ -20,7 +20,7 @@ partition_keys=
     month
     day
 [selection]
-product_type=ensemble_mean
+product_type=reanalysis
 format=grib
 grid=o1280
 variable=

--- a/configs/era5_example_config_using_date.cfg
+++ b/configs/era5_example_config_using_date.cfg
@@ -28,7 +28,7 @@ partition_keys=
      date
      pressure_level
 [selection]
-product_type=ensemble_mean
+product_type=reanalysis
 format=netcdf
 variable=
     divergence

--- a/configs/mars_example_config.cfg
+++ b/configs/mars_example_config.cfg
@@ -37,6 +37,7 @@ grid=0.125/0.125
 expver=1
 time=0000/1800
 date=2017-01-01/to/2017-01-07
+# these are weather forecasts
 type=fc
 class=od
 expect=anymars 


### PR DESCRIPTION
This change reflects the more common use cases for the Era 5 dataset.