### PR TITLE
`weather-dl`: Fix GCS timeout issues the pipelines intermittently experiences.

### DIFF
--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -24,6 +24,7 @@ import typing as t
 import warnings
 
 import apache_beam as beam
+from apache_beam.io.gcp.gcsio import WRITE_CHUNK_SIZE
 from apache_beam.options.pipeline_options import (
     DebugOptions,
     PipelineOptions,
@@ -243,7 +244,7 @@ def fetch_data(config: t.Dict,
             # upload blob to cloud storage
             logger.info(f'Uploading to store for {target!r}.')
             with store.open(target, 'wb') as dest:
-                shutil.copyfileobj(temp, dest)
+                shutil.copyfileobj(temp, dest, WRITE_CHUNK_SIZE)
 
             logger.info(f'Upload to store complete for {target!r}.')
 

--- a/weather_dl/download_pipeline/stores.py
+++ b/weather_dl/download_pipeline/stores.py
@@ -20,6 +20,7 @@ import tempfile
 import typing as t
 
 from apache_beam.io.filesystems import FileSystems
+from apache_beam.utils import retry
 
 
 class Store(abc.ABC):
@@ -96,6 +97,8 @@ class LocalFileStore(Store):
 class FSStore(Store):
     """Store data into any store supported by Apache Beam's FileSystems."""
 
+    @retry.with_exponential_backoff(
+        retry_filter=retry.retry_on_server_errors_and_timeout_filter)
     def open(self, filename: str, mode: str = 'r') -> t.IO:
         """Open object in cloud bucket (or local file system) as a read or write channel.
 


### PR DESCRIPTION
- When copying file objects, we now write the full WRITE_CHUNK_SIZE limit for GCS.
- For the FSStore, we've added an Apache Beam retry with backoff, filtering by server errors and timeouts. In experimental runs, this solution appears to fix the timeout. 