### PR TITLE
Default behavior is better

### DIFF
--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -401,7 +401,6 @@ def run(argv: t.List[str], save_main_session: bool = True):
                     project=table.project,
                     dataset=table.dataset_id,
                     table=table.table_id,
-                    method='STREAMING_INSERTS',
                     write_disposition=BigQueryDisposition.WRITE_APPEND,
                     create_disposition=BigQueryDisposition.CREATE_NEVER)
         )


### PR DESCRIPTION
We want the default behavior as described in the Apache Beam documentation:
```
method – The method to use to write to BigQuery. It may be STREAMING_INSERTS, FILE_LOADS, or DEFAULT. DEFAULT will use STREAMING_INSERTS on Streaming pipelines and FILE_LOADS on Batch pipelines.
```

Batch loads are free and much more efficient for large datasets, so on batch pipelines, that is what we want to do.

[1]https://beam.apache.org/releases/pydoc/2.35.0/apache_beam.io.gcp.bigquery.html#:~:text=DEFAULT%20will%20use%20STREAMING_INSERTS%20on%20Streaming%20pipelines%20and%20FILE_LOADS%20on%20Batch%20pipelines.