### PR TITLE
Coercing timedelta to float

### DIFF
--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -185,7 +185,7 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
         return None
     elif type(value) == np.timedelta64:
         # Return time delta in seconds.
-        return value / np.timedelta64(1, 's')
+        return float(value / np.timedelta64(1, 's'))
     # This check must happen after processing np.timedelta64 and np.datetime64.
     elif np.issubdtype(type(value), np.integer):
         return int(value)

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -108,6 +108,7 @@ class ExtractRowsTestBase(unittest.TestCase):
     def assertRowsEqual(self, actual: t.Dict, expected: t.Dict):
         for key in expected.keys():
             self.assertAlmostEqual(actual[key], expected[key], places=4)
+            self.assertNotIsInstance(actual[key], np.dtype)
 
 
 class ExtractRowsTest(ExtractRowsTestBase):

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -106,9 +106,12 @@ class ExtractRowsTestBase(unittest.TestCase):
         self.test_data_folder = f'{next(iter(weather_mv.__path__))}/test_data'
 
     def assertRowsEqual(self, actual: t.Dict, expected: t.Dict):
+        self.assertEqual(actual.keys(), expected.keys())
         for key in expected.keys():
             self.assertAlmostEqual(actual[key], expected[key], places=4)
             self.assertNotIsInstance(actual[key], np.dtype)
+            self.assertNotIsInstance(actual[key], np.float64)
+            self.assertNotIsInstance(actual[key], np.float32)
 
 
 class ExtractRowsTest(ExtractRowsTestBase):


### PR DESCRIPTION
Fixes #81. 

- Added tests to be sure that no values are `np.float64`s
- Found and fixed the JSON serialization error. 