### PR TITLE
`weather-mv` – Fixed error writing to BigQuery: Excluding non-coordinate indexes if they don't appear in the Schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ecCodes for Grib support
       run: |
-        apt-get --assume-yes install libeccodes-dev
+        sudo apt-get update
+        sudo apt-get --assume-yes install libeccodes-dev
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install ecCodes for Grib support
       run: |
-        apt-get update
         apt-get --assume-yes install libeccodes-dev
     - name: Get pip cache dir
       id: pip-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install ecCodes for Grib support
+      run: |
+        apt-get update
+        apt-get --assume-yes install libeccodes-dev
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -25,7 +25,8 @@ _Common options_:
 
 * `-i, --uris`: (required) URI prefix matching input netcdf objects. Ex: gs://ecmwf/era5/era5-2015-""
 * `-o, --output_table`: (required) Full name of destination BigQuery table. Ex: my_project.my_dataset.my_table
-* `-v, --variables`:  Target variables for the BigQuery schema. Default: will import all data variables as columns.
+* `-v, --variables`:  Target variables (or coordinates) for the BigQuery schema. Default: will import all data variables
+  as columns.
 * `-a, --area`:  Target area in [N, W, S, E]. Default: Will include all available area.
 * `--topic`: A Pub/Sub topic for GCS OBJECT_FINALIZE events, or equivalent, of a cloud bucket. E.g. 'projects/<
   PROJECT_ID>/topics/<TOPIC_ID>'.

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -37,9 +37,15 @@ from .pipeline import (
 logger = logging.getLogger(__name__)
 
 
-class SchemaCreationTests(unittest.TestCase):
+class TestDataBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_data_folder = f'{next(iter(weather_mv.__path__))}/test_data'
+
+
+class SchemaCreationTests(TestDataBase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.test_dataset = {
             "coords": {"a": {"dims": ("a",), "data": [pd.Timestamp(0)], "attrs": {}}},
             "attrs": {},
@@ -50,6 +56,10 @@ class SchemaCreationTests(unittest.TestCase):
                 "d": {"dims": ("a",), "data": [3.0]},
             }
         }
+        self.test_single_var = xr.open_dataset(
+            f'{self.test_data_folder}/test_data_grib_single_timestep',
+            engine='cfgrib'
+        )
 
     def test_schema_generation(self):
         ds = xr.Dataset.from_dict(self.test_dataset)
@@ -99,14 +109,29 @@ class SchemaCreationTests(unittest.TestCase):
             target_variables = ['a', 'foobar', 'd']
             _only_target_vars(xr.Dataset.from_dict(self.test_dataset), target_variables)
 
+    def test_schema_generation__non_index_coords(self):
+        schema = dataset_to_table_schema(self.test_single_var)
+        expected_schema = [
+            SchemaField('number', 'INT64', 'NULLABLE', None, (), None),
+            SchemaField('time', 'TIMESTAMP', 'NULLABLE', None, (), None),
+            SchemaField('step', 'FLOAT64', 'NULLABLE', None, (), None),
+            SchemaField('surface', 'FLOAT64', 'NULLABLE', None, (), None),
+            SchemaField('latitude', 'FLOAT64', 'NULLABLE', None, (), None),
+            SchemaField('longitude', 'FLOAT64', 'NULLABLE', None, (), None),
+            SchemaField('valid_time', 'TIMESTAMP', 'NULLABLE', None, (), None),
+            SchemaField('z', 'FLOAT64', 'NULLABLE', None, (), None),
+            SchemaField('data_import_time', 'TIMESTAMP', 'NULLABLE', None, (), None),
+            SchemaField('data_uri', 'STRING', 'NULLABLE', None, (), None),
+            SchemaField('data_first_step', 'TIMESTAMP', 'NULLABLE', None, (), None),
 
-class ExtractRowsTestBase(unittest.TestCase):
+        ]
+        self.assertListEqual(schema, expected_schema)
 
-    def setUp(self) -> None:
-        self.test_data_folder = f'{next(iter(weather_mv.__path__))}/test_data'
+
+class ExtractRowsTestBase(TestDataBase):
 
     def assertRowsEqual(self, actual: t.Dict, expected: t.Dict):
-        self.assertEqual(actual.keys(), expected.keys())
+        self.assertEqual(expected.keys(), actual.keys())
         for key in expected.keys():
             self.assertAlmostEqual(actual[key], expected[key], places=4)
             self.assertNotIsInstance(actual[key], np.dtype)
@@ -267,10 +292,36 @@ class ExtractRowsGribSupportTest(ExtractRowsTestBase):
         self.assertRowsEqual(actual, expected)
 
     @_handle_missing_grib_be
+    def test_extract_rows__with_vars__excludes_non_index_coords(self):
+        actual = next(extract_rows(self.test_data_path, variables=['z']))
+        expected = {
+            'data_import_time': '1970-01-01T00:00:00+00:00',
+            'data_first_step': '2021-10-18T06:00:00+00:00',
+            'data_uri': self.test_data_path,
+            'latitude': 90.0,
+            'longitude': -180.0,
+            'z': 1.42578125,
+        }
+        self.assertRowsEqual(actual, expected)
+
+    @_handle_missing_grib_be
+    def test_extract_rows__with_vars__includes_coordinates_in_vars(self):
+        actual = next(extract_rows(self.test_data_path, variables=['z', 'step']))
+        expected = {
+            'data_import_time': '1970-01-01T00:00:00+00:00',
+            'data_first_step': '2021-10-18T06:00:00+00:00',
+            'data_uri': self.test_data_path,
+            'latitude': 90.0,
+            'longitude': -180.0,
+            'step': 0,
+            'z': 1.42578125,
+        }
+        self.assertRowsEqual(actual, expected)
+
+    @_handle_missing_grib_be
     def test_multiple_editions(self):
         self.test_data_path = f'{self.test_data_folder}/test_data_grib_multiple_edition_single_timestep.bz2'
         actual = next(extract_rows(self.test_data_path))
-        print(actual)
         expected = {
             'cape': 0.0,
             'cbh': None,


### PR DESCRIPTION
I've added tests to confirm a corner case: When users supply variables for the BQ schema, we added extra columns in extract_rows that were not represented in the schema. This change addresses this in two ways:
- We've made it possible supply non-data_vars to the `-v` argument. This way, users can get non-indexed coordinate info like `step` and `valid_time` without inferring the schema.
- If `-v` is supplied, we skip adding non-explicit non-indexed coordinate info to the extracted rows.

This bug primarily affects streaming ingestion of weather-data into BQ. It causes a somewhat silent failure, as no data gets written since BQ enters an infinite retry loop (only during streaming ingestion).

Ideally, this should fix #94.