### PR TITLE
Announcing open developer meetings. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,10 +85,12 @@ setup.py  # Project is pip-installable, project requirements managed here.
 
 ### Windows Developer Instructions
 
-Windows support for each CLI is currently under development (See [#64](https://github.com/google/weather-tools/issues/64)).
-However, there are workarounds available for running the weather tools outside of installation with `pip`.
+Windows support for each CLI is currently under development (
+See [#64](https://github.com/google/weather-tools/issues/64)). However, there are workarounds available for running the
+weather tools outside of installation with `pip`.
 
 First, the would-be pip-installed script can be run directly with python like so:
+
 ```shell
 python weather_dl/weather-dl --help
 ```
@@ -168,3 +170,13 @@ After the docs are re-generated, you can view them by starting a local file serv
 ```shell
 python -m http.server -d docs/_build/html
 ```
+
+## Developer Meetings
+
+To facilitate internal and community support of weather tools, we invite you to join our regular developer meetings.
+Since our contributors are in a wide range of time zones, we offer two bi-weekly meetings: Wednesdays at 8:30 AM PST and
+Fridays at 3:00 PM PST. Feel free to attend to only one meeting every two weeks, whichever best works with your
+schedule.
+
+[Here is a calendar](https://calendar.google.com/calendar/u/0?cid=Y19uYzJhNXVxMzE1ZnAzb2U1bWUwMGw2NTBxOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+of our regular developer meetings. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,18 @@ submitting a change-list (CL).
 In general, we're happier reviewing many small PRs over fewer, larger changes. Please try to
 submit [small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html).
 
+## Developer Meetings
+
+To facilitate internal and community support of weather tools, we invite you to join our regular developer meetings.
+Since our contributors are in a wide range of time zones, we offer two fortnightly meetings: Wednesdays at 8:30 AM PST
+and Fridays at 3:00 PM PST. Feel free to attend to only one meeting every two weeks, whichever best works with your
+schedule. Our first open meeting will occur on Friday, January 28th, 2022 (the first morning meeting will be held on
+Wednesday, February 2nd, 2022).
+
+[Here is a calendar](https://calendar.google.com/calendar/u/0?cid=Y19uYzJhNXVxMzE1ZnAzb2U1bWUwMGw2NTBxOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+of our meeting schedule,
+and [here are our meeting notes](https://docs.google.com/document/d/1V2iISi-ZZNmrcImrPV7UYQGFNAe9XQ_-TB8iPggfmbo/edit).
+
 ## Project Structure
 
 ```
@@ -170,13 +182,3 @@ After the docs are re-generated, you can view them by starting a local file serv
 ```shell
 python -m http.server -d docs/_build/html
 ```
-
-## Developer Meetings
-
-To facilitate internal and community support of weather tools, we invite you to join our regular developer meetings.
-Since our contributors are in a wide range of time zones, we offer two bi-weekly meetings: Wednesdays at 8:30 AM PST and
-Fridays at 3:00 PM PST. Feel free to attend to only one meeting every two weeks, whichever best works with your
-schedule.
-
-[Here is a calendar](https://calendar.google.com/calendar/u/0?cid=Y19uYzJhNXVxMzE1ZnAzb2U1bWUwMGw2NTBxOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
-of our regular developer meetings. 


### PR DESCRIPTION
Since we have contributors in a wide range of time zones, we'll be hosting two dev syncs, one in the morning and one in the afternoon. We'll keep meeting minutes in one central doc / over collaboration tools via GitHub. 

Fixes #78.

CC: @CillianFn @saveriogzz @pranay101