### PR TITLE
Upload to cloud is robust to socket timeout errors.

### DIFF
--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -33,13 +33,12 @@ from apache_beam.options.pipeline_options import (
     WorkerOptions,
     StandardOptions,
 )
-from apache_beam.utils import retry
 
 from .clients import CLIENTS
 from .manifest import Manifest, Location, NoOpManifest, LocalManifest
 from .parsers import process_config, parse_manifest_location, use_date_as_directory
-from .stores import Store, TempFileStore, FSStore, LocalFileStore, \
-    _retry_if_valid_input_but_server_or_socket_error_and_timeout_filter
+from .stores import Store, TempFileStore, FSStore, LocalFileStore
+from .util import retry_with_exponential_backoff
 
 logger = logging.getLogger(__name__)
 
@@ -219,8 +218,7 @@ def assemble_partition_config(partition: t.Tuple,
     return out
 
 
-@retry.with_exponential_backoff(
-    retry_filter=_retry_if_valid_input_but_server_or_socket_error_and_timeout_filter)
+@retry_with_exponential_backoff
 def upload(store: Store, src: io.FileIO, dest: str) -> None:
     """Upload blob to cloud storage."""
     with store.open(dest, 'wb') as dest_:

--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -327,6 +327,7 @@ class UploadTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as src:
             src.writelines(self.message)
             src.flush()
+            src.seek(0)
             with tempfile.NamedTemporaryFile('wb') as dst:
                 upload(self.store, src, dst.name)
                 with open(dst.name, 'rb') as dst1:

--- a/weather_dl/download_pipeline/stores.py
+++ b/weather_dl/download_pipeline/stores.py
@@ -16,12 +16,12 @@
 import abc
 import io
 import os
-import socket
 import tempfile
 import typing as t
 
 from apache_beam.io.filesystems import FileSystems
-from apache_beam.utils import retry
+
+from .util import retry_with_exponential_backoff
 
 
 class Store(abc.ABC):
@@ -95,19 +95,10 @@ class LocalFileStore(Store):
         return os.path.exists(os.sep.join([self.dir, filename]))
 
 
-def _retry_if_valid_input_but_server_or_socket_error_and_timeout_filter(exception) -> bool:
-    if isinstance(exception, socket.timeout):
-        return True
-    if isinstance(exception, TimeoutError):
-        return True
-    return retry.retry_if_valid_input_but_server_error_and_timeout_filter(exception)
-
-
 class FSStore(Store):
     """Store data into any store supported by Apache Beam's FileSystems."""
 
-    @retry.with_exponential_backoff(
-        retry_filter=_retry_if_valid_input_but_server_or_socket_error_and_timeout_filter)
+    @retry_with_exponential_backoff
     def open(self, filename: str, mode: str = 'r') -> t.IO:
         """Open object in cloud bucket (or local file system) as a read or write channel.
 

--- a/weather_dl/download_pipeline/util.py
+++ b/weather_dl/download_pipeline/util.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import socket
+import sys
+
+from apache_beam.utils import retry
+
+
+def _retry_if_valid_input_but_server_or_socket_error_and_timeout_filter(exception) -> bool:
+    if isinstance(exception, socket.timeout):
+        return True
+    if isinstance(exception, TimeoutError):
+        return True
+    return retry.retry_if_valid_input_but_server_error_and_timeout_filter(exception)
+
+
+class _FakeClock:
+    def sleep(self, value):
+        pass
+
+
+def retry_with_exponential_backoff(fun):
+    """A retry decorator that doesn't apply during test time."""
+    clock = retry.Clock()
+
+    # Use a fake clock only during test time...
+    if 'unittest' in sys.modules.keys():
+        clock = _FakeClock()
+
+    return retry.with_exponential_backoff(
+        retry_filter=_retry_if_valid_input_but_server_or_socket_error_and_timeout_filter,
+        clock=clock,
+    )(fun)


### PR DESCRIPTION
Fixes #109.

- Created a Beam retry filter to account for socket timeouts.
- Applied filter to both the file open and file upload steps.