### PR TITLE
New partitioning strategy for `weather-dl`

### DIFF
--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -96,7 +96,7 @@ class CdsClient(Client):
         CDS has dynamic, data-specific limits, defined here:
           https://cds.climate.copernicus.eu/live/limits
 
-        Typically, the reanalysis dataset allows for 3-5 simultaneous requets.
+        Typically, the reanalysis dataset allows for 3-5 simultaneous requests.
         For all standard CDS data (backed on disk drives), it's common that 2
         requests are allowed, though this is dynamically set, too.
 

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -140,7 +140,14 @@ def _create_partition_config(option: t.Tuple, config: t.Dict, index: int = -1) -
 
 
 def partition_by_index(config: t.Dict, num_partitions: int) -> int:
-    """Split config partitions into groups based on their `__index__` value."""
+    """Split config partitions into groups based on their `__index__` value.
+
+    Args:
+       config: A sharded download config with an `__index__` int in the `parameters` section.
+       num_partitions: must be 1 or greater.
+    Returns:
+        The partition index.
+    """
     index = config.get('parameters', {}).get('__index__', -1)
     if index == -1:
         return index

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -57,7 +57,7 @@ def configure_workers(client_name: str,
     """Configure the number of workers and threads for the pipeline, allowing for user control."""
 
     # The number of workers should always be proportional to the number of licenses.
-    num_api_keys = config.get('parameters', {}).get('num_api_keys', 1)
+    num_api_keys = len(get_subsections(config))
 
     # If user doesn't specify a number of requestors, make educated guess based on clients and dataset.
     if num_requesters_per_key == -1:

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -340,6 +340,6 @@ def run(argv: t.List[str], save_main_session: bool = True):
         for idx, dl_shards in enumerate(dl_shards_by_keys):
             (
                     dl_shards
-                    | 'Assemble' >> beam.Map(assemble_partition, params=subsections[idx], manifest=manifest)
-                    | 'FetchData' >> beam.Map(fetch_data, client_name=client_name, manifest=manifest, store=store)
+                    | f'Assemble{idx}' >> beam.Map(assemble_partition, params=subsections[idx], manifest=manifest)
+                    | f'FetchData{idx}' >> beam.Map(fetch_data, client_name=client_name, manifest=manifest, store=store)
             )

--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -61,6 +61,10 @@ class ConfigureWorkersTest(unittest.TestCase):
             }
         }
 
+    def add_api_keys(self,  n: int) -> None:
+        for i in range(n):
+            self.config['parameters'][f'subsection{i}'] = {'api_key': f'A{i}', 'api_url': f'U{i}'}
+
     def test_fake_client(self):
         opts = configure_workers('fake', self.config, -1, PipelineOptions([]))
         expected = {
@@ -72,7 +76,7 @@ class ConfigureWorkersTest(unittest.TestCase):
         self.assertEqual(expected, opts.get_all_options(drop_default=True))
 
     def test_multiple_api_keys(self):
-        self.config['parameters']['num_api_keys'] = 4
+        self.add_api_keys(4)
         opts = configure_workers('fake', self.config, -1, PipelineOptions([]))
         expected = {
             'experiments': ['use_runner_v2'],
@@ -83,7 +87,7 @@ class ConfigureWorkersTest(unittest.TestCase):
         self.assertEqual(expected, opts.get_all_options(drop_default=True))
 
     def test_multiple_api_keys__rounds_up(self):
-        self.config['parameters']['num_api_keys'] = 5
+        self.add_api_keys(5)
         opts = configure_workers('fake', self.config, -1, PipelineOptions([]))
         expected = {
             'experiments': ['use_runner_v2'],
@@ -105,7 +109,7 @@ class ConfigureWorkersTest(unittest.TestCase):
 
     def test_user_specifies_threads(self):
         args = '--number_of_worker_harness_threads 3 --experiments use_runner_v2'.split()
-        self.config['parameters']['num_api_keys'] = 15
+        self.add_api_keys(15)
         opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
         expected = {
             'experiments': ['use_runner_v2'],
@@ -117,7 +121,7 @@ class ConfigureWorkersTest(unittest.TestCase):
 
     def test_user_specifies_threads__rounds_up(self):
         args = '--number_of_worker_harness_threads 3 --experiments use_runner_v2'.split()
-        self.config['parameters']['num_api_keys'] = 17
+        self.add_api_keys(17)
         opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
         expected = {
             'experiments': ['use_runner_v2'],
@@ -129,7 +133,7 @@ class ConfigureWorkersTest(unittest.TestCase):
 
     def test_user_specifies_workers(self):
         args = '--max_num_workers 3'.split()
-        self.config['parameters']['num_api_keys'] = 6
+        self.add_api_keys(6)
         opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
         expected = {
             'experiments': ['use_runner_v2'],
@@ -140,7 +144,7 @@ class ConfigureWorkersTest(unittest.TestCase):
 
     def test_user_specifies_workers__rounds_up(self):
         args = '--max_num_workers 3'.split()
-        self.config['parameters']['num_api_keys'] = 7
+        self.add_api_keys(7)
         opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
         expected = {
             'experiments': ['use_runner_v2'],
@@ -151,7 +155,7 @@ class ConfigureWorkersTest(unittest.TestCase):
 
     def test_user_specifies_workers__large(self):
         args = '--max_num_workers 12'.split()
-        self.config['parameters']['num_api_keys'] = 7
+        self.add_api_keys(7)
         with self.assertWarnsRegex(
                 Warning,
                 "Max number of workers 12 with 2 threads each exceeds recommended 7 concurrent requests."

--- a/weather_dl/setup.py
+++ b/weather_dl/setup.py
@@ -32,7 +32,7 @@ base_requirements = [
 setup(
     name='download_pipeline',
     packages=find_packages(),
-    version='0.1.1',
+    version='0.2.0',
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
     url='https://weather-tools.readthedocs.io/en/latest/weather_dl/',

--- a/weather_dl/setup.py
+++ b/weather_dl/setup.py
@@ -32,7 +32,7 @@ base_requirements = [
 setup(
     name='download_pipeline',
     packages=find_packages(),
-    version='0.2.0',
+    version='0.1.2',
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
     url='https://weather-tools.readthedocs.io/en/latest/weather_dl/',


### PR DESCRIPTION
In this new scheme, we make use of `beam.Partition` to split work by available license (via param subsections). This simplifies a lot of the pipeline logic.

E2E tests will validate if this, indeed, fixes #98.