### PR TITLE
New data-oriented task distribution strategy.

### DIFF
--- a/weather_dl/download_pipeline/fetcher.py
+++ b/weather_dl/download_pipeline/fetcher.py
@@ -89,5 +89,5 @@ class Fetcher(beam.DoFn):
         logger.info(f"[{worker_name}] Starting requests...")
 
         for partition in partitions:
-            beam.metrics.Metrics.counter('Fetcher', worker_name).inc()
+            beam.metrics.Metrics.counter('Fetcher', subsection).inc()
             self.fetch_data(partition, worker_name=worker_name)

--- a/weather_dl/download_pipeline/fetcher.py
+++ b/weather_dl/download_pipeline/fetcher.py
@@ -1,0 +1,93 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import dataclasses
+import io
+import logging
+import shutil
+import tempfile
+import typing as t
+
+import apache_beam as beam
+from apache_beam.io.gcp.gcsio import WRITE_CHUNK_SIZE
+
+from .clients import CLIENTS
+from .manifest import Manifest, NoOpManifest, Location
+from .parsers import prepare_target_name
+from .stores import Store, FSStore
+from .util import retry_with_exponential_backoff
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class Fetcher(beam.DoFn):
+    """Executes client download requests.
+
+    Given a sequence of configs (keyed by subsection parameters and number of allowed
+    requests), this will execute retrievals via each client. The keyed strucutre, the
+    result of a `beam.GroupBy` operation, will ensure that all licenses and requests
+    are utilized without any conflict.
+
+    Attributes:
+        client_name: The name of the download client to construct per each request.
+        manifest: A manifest to keep track of the status of requests
+        store: To manage where downloads are persisted.
+    """
+
+    client_name: str
+    manifest: Manifest = NoOpManifest(Location('noop://in-memory'))
+    store: t.Optional[Store] = None
+
+    def __post_init__(self):
+        if self.store is None:
+            self.store = FSStore()
+
+    @retry_with_exponential_backoff
+    def upload(self, src: io.FileIO, dest: str) -> None:
+        """Upload blob to cloud storage, with retries."""
+        with self.store.open(dest, 'wb') as dest_:
+            shutil.copyfileobj(src, dest_, WRITE_CHUNK_SIZE)
+
+    def fetch_data(self, config: t.Dict) -> None:
+        """Download data from a client to a temp file, then upload to Cloud Storage."""
+        if not config:
+            return
+
+        client = CLIENTS[self.client_name](config)
+        target = prepare_target_name(config)
+        dataset = config['parameters'].get('dataset', '')
+        selection = config['selection']
+        user = config['parameters'].get('user_id', 'unknown')
+
+        with self.manifest.transact(selection, target, user):
+            with tempfile.NamedTemporaryFile() as temp:
+                logger.info(f'Fetching data for {target!r}.')
+                client.retrieve(dataset, selection, temp.name)
+
+                logger.info(f'Uploading to store for {target!r}.')
+                self.upload(temp, target)
+
+                logger.info(f'Upload to store complete for {target!r}.')
+
+    def process(self, element) -> None:
+        # element: Tuple[Tuple[str, int], Iterator[Config]]
+        """Execute download requests one-by-one."""
+        (subsection, request_idx), partitions = element
+        worker_name = f'{subsection}.{request_idx}'
+
+        logger.info(f"[{worker_name}] Starting requests...")
+
+        for partition in partitions:
+            self.fetch_data(partition)
+            beam.metrics.Metrics.counter('Fetcher', worker_name).inc()

--- a/weather_dl/download_pipeline/fetcher_test.py
+++ b/weather_dl/download_pipeline/fetcher_test.py
@@ -1,0 +1,202 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import socket
+import tempfile
+import typing as t
+import unittest
+from unittest.mock import patch, ANY
+
+from .fetcher import Fetcher
+from .manifest import MockManifest, Location
+from .stores import InMemoryStore, FSStore
+
+
+class UploadTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.message = b'the quick brown fox jumped over the lazy dog'.split()
+        self.store = FSStore()
+        self.fetcher = Fetcher('fake', store=self.store)
+
+    def test_upload_writes_to_store(self):
+        with tempfile.NamedTemporaryFile() as src:
+            src.writelines(self.message)
+            src.flush()
+            src.seek(0)
+            with tempfile.NamedTemporaryFile('wb') as dst:
+                self.fetcher.upload(src, dst.name)
+                with open(dst.name, 'rb') as dst1:
+                    self.assertEqual(dst1.readlines()[0], b''.join(self.message))
+
+    def test_retries_after_socket_timeout_error(self):
+        class SocketTimeoutStore(InMemoryStore):
+            count = 0
+
+            def open(self, filename: str, mode: str = 'r') -> t.IO:
+                self.count += 1
+                raise socket.timeout('Deliberate error.')
+
+        socket_store = SocketTimeoutStore()
+
+        fetcher = Fetcher('fake', store=socket_store)
+
+        with tempfile.NamedTemporaryFile() as src:
+            src.writelines(self.message)
+            src.flush()
+            with tempfile.NamedTemporaryFile('wb') as dst:
+                with self.assertRaises(socket.timeout):
+                    fetcher.upload(src, dst.name)
+        self.assertEqual(socket_store.count, 8)
+
+
+class FetchDataTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.dummy_manifest = MockManifest(Location('dummy-manifest'))
+
+    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
+    @patch('cdsapi.Client.retrieve')
+    def test_fetch_data(self, mock_retrieve, mock_gcs_file):
+        config = {
+            'parameters': {
+                'dataset': 'reanalysis-era5-pressure-levels',
+                'partition_keys': ['year', 'month'],
+                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
+                'api_url': 'https//api-url.com/v1/',
+                'api_key': '12345',
+            },
+            'selection': {
+                'features': ['pressure'],
+                'month': ['12'],
+                'year': ['01']
+            }
+        }
+
+        fetcher = Fetcher('cds', self.dummy_manifest, InMemoryStore())
+        fetcher.fetch_data(config)
+
+        mock_gcs_file.assert_called_with(
+            'gs://weather-dl-unittest/download-01-12.nc',
+            'wb'
+        )
+
+        mock_retrieve.assert_called_with(
+            'reanalysis-era5-pressure-levels',
+            config['selection'],
+            ANY)
+
+    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
+    @patch('cdsapi.Client.retrieve')
+    def test_fetch_data__manifest__returns_success(self, mock_retrieve, mock_gcs_file):
+        config = {
+            'parameters': {
+                'dataset': 'reanalysis-era5-pressure-levels',
+                'partition_keys': ['year', 'month'],
+                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
+                'api_url': 'https//api-url.com/v1/',
+                'api_key': '12345',
+            },
+            'selection': {
+                'features': ['pressure'],
+                'month': ['12'],
+                'year': ['01']
+            }
+        }
+
+        fetcher = Fetcher('cds', self.dummy_manifest, InMemoryStore())
+        fetcher.fetch_data(config)
+
+        self.assertDictContainsSubset(dict(
+            selection=config['selection'],
+            location='gs://weather-dl-unittest/download-01-12.nc',
+            status='success',
+            error=None,
+            user='unknown',
+        ), list(self.dummy_manifest.records.values())[0]._asdict())
+
+    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
+    @patch('cdsapi.Client.retrieve')
+    def test_fetch_data__manifest__records_retrieve_failure(self, mock_retrieve,
+                                                            mock_gcs_file):
+        config = {
+            'parameters': {
+                'dataset': 'reanalysis-era5-pressure-levels',
+                'partition_keys': ['year', 'month'],
+                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
+                'api_url': 'https//api-url.com/v1/',
+                'api_key': '12345',
+            },
+            'selection': {
+                'features': ['pressure'],
+                'month': ['12'],
+                'year': ['01']
+            }
+        }
+
+        error = IOError("We don't have enough permissions to download this.")
+        mock_retrieve.side_effect = error
+
+        with self.assertRaises(IOError) as e:
+            fetcher = Fetcher('cds', self.dummy_manifest, InMemoryStore())
+            fetcher.fetch_data(config)
+
+            actual = list(self.dummy_manifest.records.values())[0]._asdict()
+
+            self.assertDictContainsSubset(dict(
+                selection=config['selection'],
+                location='gs://weather-dl-unittest/download-01-12.nc',
+                status='failure',
+                user='unknown',
+            ), actual)
+
+            self.assertIn(error.args[0], actual['error'])
+            self.assertIn(error.args[0], e.exception.args[0])
+
+    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
+    @patch('cdsapi.Client.retrieve')
+    def test_fetch_data__manifest__records_gcs_failure(self, mock_retrieve,
+                                                       mock_gcs_file):
+        config = {
+            'parameters': {
+                'dataset': 'reanalysis-era5-pressure-levels',
+                'partition_keys': ['year', 'month'],
+                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
+                'api_url': 'https//api-url.com/v1/',
+                'api_key': '12345',
+            },
+            'selection': {
+                'features': ['pressure'],
+                'month': ['12'],
+                'year': ['01']
+            }
+        }
+
+        error = IOError("Can't open gcs file.")
+        mock_gcs_file.side_effect = error
+
+        with self.assertRaises(IOError) as e:
+            fetcher = Fetcher('cds', self.dummy_manifest, InMemoryStore())
+            fetcher.fetch_data(config)
+
+            actual = list(self.dummy_manifest.records.values())[0]._asdict()
+            self.assertDictContainsSubset(dict(
+                selection=config['selection'],
+                location='gs://weather-dl-unittest/download-01-12.nc',
+                status='failure',
+                user='unknown',
+            ), actual)
+
+            self.assertIn(error.args[0], actual['error'])
+            self.assertIn(error.args[0], e.exception.args[0])

--- a/weather_dl/download_pipeline/fetcher_test.py
+++ b/weather_dl/download_pipeline/fetcher_test.py
@@ -152,17 +152,17 @@ class FetchDataTest(unittest.TestCase):
             fetcher = Fetcher('cds', self.dummy_manifest, InMemoryStore())
             fetcher.fetch_data(config)
 
-            actual = list(self.dummy_manifest.records.values())[0]._asdict()
+        actual = list(self.dummy_manifest.records.values())[0]._asdict()
 
-            self.assertDictContainsSubset(dict(
-                selection=config['selection'],
-                location='gs://weather-dl-unittest/download-01-12.nc',
-                status='failure',
-                user='unknown',
-            ), actual)
+        self.assertDictContainsSubset(dict(
+            selection=config['selection'],
+            location='gs://weather-dl-unittest/download-01-12.nc',
+            status='failure',
+            user='unknown',
+        ), actual)
 
-            self.assertIn(error.args[0], actual['error'])
-            self.assertIn(error.args[0], e.exception.args[0])
+        self.assertIn(error.args[0], actual['error'])
+        self.assertIn(error.args[0], e.exception.args[0])
 
     @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
     @patch('cdsapi.Client.retrieve')
@@ -190,13 +190,13 @@ class FetchDataTest(unittest.TestCase):
             fetcher = Fetcher('cds', self.dummy_manifest, InMemoryStore())
             fetcher.fetch_data(config)
 
-            actual = list(self.dummy_manifest.records.values())[0]._asdict()
-            self.assertDictContainsSubset(dict(
-                selection=config['selection'],
-                location='gs://weather-dl-unittest/download-01-12.nc',
-                status='failure',
-                user='unknown',
-            ), actual)
+        actual = list(self.dummy_manifest.records.values())[0]._asdict()
+        self.assertDictContainsSubset(dict(
+            selection=config['selection'],
+            location='gs://weather-dl-unittest/download-01-12.nc',
+            status='failure',
+            user='unknown',
+        ), actual)
 
-            self.assertIn(error.args[0], actual['error'])
-            self.assertIn(error.args[0], e.exception.args[0])
+        self.assertIn(error.args[0], actual['error'])
+        self.assertIn(error.args[0], e.exception.args[0])

--- a/weather_dl/download_pipeline/parsers.py
+++ b/weather_dl/download_pipeline/parsers.py
@@ -16,6 +16,7 @@
 import configparser
 import copy as cp
 import datetime
+import os
 import io
 import json
 import string
@@ -349,15 +350,19 @@ def process_config(file: io.StringIO) -> Config:
 
 def prepare_target_name(config: t.Dict) -> str:
     """Returns name of target location."""
-    target_path = config['parameters']['target_path']
-    target_filename = config['parameters'].get('target_filename', '')
-    partition_keys = config['parameters']['partition_keys'].copy()
+    parameters = config['parameters']
+
+    target_path = parameters.get('target_path', '')
+    target_filename = parameters.get('target_filename', '')
+    partition_keys = parameters.get('partition_keys', list())
+
     if use_date_as_directory(config):
-        target_path = "{}/{}".format(
-            target_path,
-            ''.join(['/'.join(date_value for date_value in config['selection']['date'][0].split('-'))]))
+        date_vals = config['selection']['date'][0].split('-')
+        target_path = os.path.join(target_path, *date_vals)
         partition_keys.remove('date')
-    target_path = "{}{}".format(target_path, target_filename)
+
+    target_path += target_filename
+
     partition_key_values = [config['selection'][key][0] for key in partition_keys]
     target = target_path.format(*partition_key_values)
 

--- a/weather_dl/download_pipeline/parsers.py
+++ b/weather_dl/download_pipeline/parsers.py
@@ -348,13 +348,13 @@ def process_config(file: io.StringIO) -> Config:
     return config
 
 
-def prepare_target_name(config: t.Dict) -> str:
+def prepare_target_name(config: Config) -> str:
     """Returns name of target location."""
     parameters = config['parameters']
 
-    target_path = parameters.get('target_path', '')
-    target_filename = parameters.get('target_filename', '')
-    partition_keys = parameters.get('partition_keys', list())
+    target_path = t.cast(str, parameters.get('target_path', ''))
+    target_filename = t.cast(str, parameters.get('target_filename', ''))
+    partition_keys = t.cast(t.List[str], parameters.get('partition_keys', list()))
 
     if use_date_as_directory(config):
         date_vals = config['selection']['date'][0].split('-')

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -482,12 +482,12 @@ class ProcessConfigTest(unittest.TestCase):
     def test_requires_target_template_param_not_present(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                client=cds
-                target_template=bar
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=cds
+                    target_template=bar
+                    """
             ) as f:
                 process_config(f)
 
@@ -683,18 +683,18 @@ class ProcessConfigTest(unittest.TestCase):
     def test_date_as_directory_key_mismatch(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                client=cds
-                target_path=somewhere/
-                target_filename=bar-{}
-                append_date_dirs=true
-                partition_keys=
-                    date
-                [selection]
-                date=2017-01-01/to/2017-01-01
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=cds
+                    target_path=somewhere/
+                    target_filename=bar-{}
+                    append_date_dirs=true
+                    partition_keys=
+                        date
+                    [selection]
+                    date=2017-01-01/to/2017-01-01
+                    """
             ) as f:
                 process_config(f)
 
@@ -705,17 +705,17 @@ class ProcessConfigTest(unittest.TestCase):
     def test_append_date_dirs_without_filename(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                client=cds
-                target_path=somewhere/
-                append_date_dirs=true
-                partition_keys=
-                    date
-                [selection]
-                date=2017-01-01/to/2017-01-01
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=cds
+                    target_path=somewhere/
+                    append_date_dirs=true
+                    partition_keys=
+                        date
+                    [selection]
+                    date=2017-01-01/to/2017-01-01
+                    """
             ) as f:
                 process_config(f)
 
@@ -726,18 +726,18 @@ class ProcessConfigTest(unittest.TestCase):
     def test_append_date_dirs_without_date_partition(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                client=cds
-                target_path=somewhere/
-                target_filename=bar
-                append_date_dirs=true
-                partition_keys=
-                    pressure
-                [selection]
-                pressure=500
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=cds
+                    target_path=somewhere/
+                    target_filename=bar
+                    append_date_dirs=true
+                    partition_keys=
+                        pressure
+                    [selection]
+                    pressure=500
+                    """
             ) as f:
                 process_config(f)
 
@@ -748,16 +748,16 @@ class ProcessConfigTest(unittest.TestCase):
     def test_append_date_dirs_without_partition_keys(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                client=cds
-                target_path=somewhere/
-                target_filename=bar
-                append_date_dirs=true
-                [selection]
-                pressure=500
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=cds
+                    target_path=somewhere/
+                    target_filename=bar
+                    append_date_dirs=true
+                    [selection]
+                    pressure=500
+                    """
             ) as f:
                 process_config(f)
 
@@ -767,18 +767,18 @@ class ProcessConfigTest(unittest.TestCase):
 
     def test_date_as_directory_target_directory_ends_in_slash(self):
         with io.StringIO(
-            """
-            [parameters]
-            dataset=foo
-            client=cds
-            target_path=somewhere/
-            target_filename=bar
-            append_date_dirs=true
-            partition_keys=
-                date
-            [selection]
-            date=2017-01-01/to/2017-01-01
-            """
+                """
+                [parameters]
+                dataset=foo
+                client=cds
+                target_path=somewhere/
+                target_filename=bar
+                append_date_dirs=true
+                partition_keys=
+                    date
+                [selection]
+                date=2017-01-01/to/2017-01-01
+                """
         ) as f:
             config = process_config(f)
             self.assertEqual(config['parameters']['target_path'], "somewhere")
@@ -786,16 +786,16 @@ class ProcessConfigTest(unittest.TestCase):
     def test_client_not_set(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                target_path=bar-{}
-                partition_keys=
-                    year
-                [selection]
-                year=
-                    1969
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    target_path=bar-{}
+                    partition_keys=
+                        year
+                    [selection]
+                    year=
+                        1969
+                    """
             ) as f:
                 process_config(f)
 
@@ -806,17 +806,17 @@ class ProcessConfigTest(unittest.TestCase):
     def test_client_invalid(self):
         with self.assertRaises(ValueError) as ctx:
             with io.StringIO(
-                """
-                [parameters]
-                dataset=foo
-                client=nope
-                target_path=bar-{}
-                partition_keys=
-                    year
-                [selection]
-                year=
-                    1969
-                """
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=nope
+                    target_path=bar-{}
+                    partition_keys=
+                        year
+                    [selection]
+                    year=
+                        1969
+                    """
             ) as f:
                 process_config(f)
 
@@ -826,110 +826,107 @@ class ProcessConfigTest(unittest.TestCase):
 
 
 class PrepareTargetNameTest(unittest.TestCase):
+    TEST_CASES = [
+        dict(case='No date.',
+             config={
+                 'parameters': {
+                     'partition_keys': ['year', 'month'],
+                     'target_path': 'download-{}-{}.nc',
+                     'force_download': False
+                 },
+                 'selection': {
+                     'features': ['pressure'],
+                     'month': ['12'],
+                     'year': ['02']
+                 }
+             },
+             expected='download-02-12.nc'),
+        dict(case='Has date but no target directory.',
+             config={
+                 'parameters': {
+                     'partition_keys': ['date'],
+                     'target_path': 'download-{}.nc',
+                     'force_download': False
+                 },
+                 'selection': {
+                     'features': ['pressure'],
+                     'date': ['2017-01-15'],
+                 }
+             },
+             expected='download-2017-01-15.nc'),
+        dict(case='Has Directory, but no date',
+             config={
+                 'parameters': {
+                     'target_path': 'somewhere/',
+                     'partition_keys': ['year', 'month'],
+                     'target_filename': 'download/{}/{}.nc',
+                     'force_download': False
+                 },
+                 'selection': {
+                     'features': ['pressure'],
+                     'month': ['12'],
+                     'year': ['02']
+                 }
+             },
+             expected='somewhere/download/02/12.nc'),
+        dict(case='Had date and target directory',
+             config={
+                 'parameters': {
+                     'partition_keys': ['date'],
+                     'target_path': 'somewhere',
+                     'target_filename': '-download.nc',
+                     'append_date_dirs': 'true',
+                     'force_download': False
+                 },
+                 'selection': {
+                     'date': ['2017-01-15'],
+                 }
+             },
+             expected='somewhere/2017/01/15-download.nc'),
+        dict(case='Had date, target directory, and additional params.',
+             config={
+                 'parameters': {
+                     'partition_keys': ['date', 'pressure_level'],
+                     'target_path': 'somewhere',
+                     'target_filename': '-pressure-{}.nc',
+                     'append_date_dirs': 'true',
+                     'force_download': False
+                 },
+                 'selection': {
+                     'features': ['pressure'],
+                     'pressure_level': ['500'],
+                     'date': ['2017-01-15'],
+                 }
+             },
+             expected='somewhere/2017/01/15-pressure-500.nc'),
+        dict(case='Has date and target directory, including parameters in path.',
+             config={
+                 'parameters': {
+                     'partition_keys': ['date', 'expver', 'pressure_level'],
+                     'target_path': 'somewhere/expver-{}',
+                     'target_filename': '-pressure-{}.nc',
+                     'append_date_dirs': 'true',
+                     'force_download': False
+                 },
+                 'selection': {
+                     'features': ['pressure'],
+                     'pressure_level': ['500'],
+                     'date': ['2017-01-15'],
+                     'expver': ['1'],
+                 }
+             },
+             expected='somewhere/expver-1/2017/01/15-pressure-500.nc'),
+
+    ]
 
     def setUp(self) -> None:
         self.dummy_manifest = MockManifest(Location('dummy-manifest'))
 
-    def test_target_name_no_date(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['year', 'month'],
-                'target_path': 'download-{}-{}.nc',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['02']
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "download-02-12.nc")
-
-    def test_target_name_date_no_target_directory(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date'],
-                'target_path': 'download-{}.nc',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'date': ['2017-01-15'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "download-2017-01-15.nc")
-
-    def test_target_name_target_directory_no_date(self):
-        config = {
-            'parameters': {
-                'target_path': 'somewhere/',
-                'partition_keys': ['year', 'month'],
-                'target_filename': 'download/{}/{}.nc',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['02']
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/download/02/12.nc")
-
-    def test_target_name_date_and_target_directory(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date'],
-                'target_path': 'somewhere',
-                'target_filename': '-download.nc',
-                'append_date_dirs': 'true',
-                'force_download': False
-            },
-            'selection': {
-                'date': ['2017-01-15'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/2017/01/15-download.nc")
-
-    def test_target_name_date_and_target_directory_additional_partitions(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date', 'pressure_level'],
-                'target_path': 'somewhere',
-                'target_filename': '-pressure-{}.nc',
-                'append_date_dirs': 'true',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'pressure_level': ['500'],
-                'date': ['2017-01-15'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/2017/01/15-pressure-500.nc")
-
-    def test_target_name_date_and_target_directory_additional_partitions_in_path(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date', 'expver', 'pressure_level'],
-                'target_path': 'somewhere/expver-{}',
-                'target_filename': '-pressure-{}.nc',
-                'append_date_dirs': 'true',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'pressure_level': ['500'],
-                'date': ['2017-01-15'],
-                'expver': ['1'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/expver-1/2017/01/15-pressure-500.nc")
+    def test_target_name(self):
+        for it in self.TEST_CASES:
+            with self.subTest(msg=it['case'], **it):
+                actual = prepare_target_name(it['config'])
+                self.assertEqual(actual, it['expected'])
 
 
 if __name__ == '__main__':

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -15,17 +15,13 @@
 import argparse
 import copy as cp
 import getpass
-import io
 import itertools
 import logging
 import os
-import shutil
-import tempfile
 import typing as t
 import warnings
 
 import apache_beam as beam
-from apache_beam.io.gcp.gcsio import WRITE_CHUNK_SIZE
 from apache_beam.options.pipeline_options import (
     DebugOptions,
     PipelineOptions,
@@ -35,12 +31,19 @@ from apache_beam.options.pipeline_options import (
 )
 
 from .clients import CLIENTS
+from .fetcher import Fetcher
 from .manifest import Manifest, Location, NoOpManifest, LocalManifest
-from .parsers import process_config, parse_manifest_location, use_date_as_directory
+from .parsers import (
+    Config,
+    parse_manifest_location,
+    prepare_target_name,
+    process_config,
+)
 from .stores import Store, TempFileStore, FSStore, LocalFileStore
-from .util import retry_with_exponential_backoff
 
 logger = logging.getLogger(__name__)
+
+Partition = t.Tuple[str, t.Dict, Config]
 
 
 def configure_logger(verbosity: int) -> None:
@@ -67,7 +70,7 @@ def configure_workers(client_name: str,
 
     max_num_requesters = num_requesters_per_key * num_api_keys
 
-    # Default: Assume user intends to have two thread per worker.
+    # Default: Assume user intends to have two threads per worker.
     if pipeline_options.view_as(DebugOptions).number_of_worker_harness_threads is None:
         pipeline_options.view_as(DebugOptions).add_experiment('use_runner_v2')
         pipeline_options.view_as(DebugOptions).number_of_worker_harness_threads = 2
@@ -88,26 +91,7 @@ def configure_workers(client_name: str,
     return pipeline_options
 
 
-def prepare_target_name(config: t.Dict) -> str:
-    """Returns name of target location."""
-    target_path = config['parameters']['target_path']
-    target_filename = config['parameters'].get('target_filename', '')
-    partition_keys = config['parameters']['partition_keys'].copy()
-    if use_date_as_directory(config):
-        target_path = "{}/{}".format(
-            target_path,
-            ''.join(['/'.join(date_value for date_value in config['selection']['date'][0].split('-'))]))
-        logger.debug(f'target_path adjusted for date: {target_path}')
-        partition_keys.remove('date')
-    target_path = "{}{}".format(target_path, target_filename)
-    partition_key_values = [config['selection'][key][0] for key in partition_keys]
-    target = target_path.format(*partition_key_values)
-    logger.debug(f'target name for partition: {target}')
-
-    return target
-
-
-def _create_partition_config(option: t.Tuple, config: t.Dict) -> t.Dict:
+def _create_partition_config(option: t.Tuple, config: Config) -> t.Dict:
     """Create a config for a single partition option.
 
     Output a config dictionary, overriding the range of values for
@@ -125,7 +109,7 @@ def _create_partition_config(option: t.Tuple, config: t.Dict) -> t.Dict:
     Returns:
         A configuration with that selects a single download partition.
     """
-    partition_keys = config['parameters']['partition_keys']
+    partition_keys = config.get('parameters', {}).get('partition_keys', [])
     selection = config.get('selection', {})
     copy = cp.deepcopy(selection)
     out = cp.deepcopy(config)
@@ -150,108 +134,112 @@ def skip_partition(config: t.Dict, store: Store) -> bool:
     return False
 
 
-def prepare_partitions(config: t.Dict, store: t.Optional[Store] = None) -> t.Iterator[t.Tuple]:
-    """Iterate over client parameters, partitioning over `partition_keys`."""
+def get_subsections(config: t.Dict) -> t.List[t.Tuple[str, t.Dict]]:
+    """Collect parameter subsections from main configuration.
+
+    If the `parameters` section contains subsections (e.g. '[parameters.1]',
+    '[parameters.2]'), collect the subsection key-value pairs. Otherwise,
+    return an empty dictionary (i.e. there are no subsections).
+
+    This is useful for specifying multiple API keys for your configuration.
+    For example:
+    ```
+      [parameters.alice]
+      api_key=KKKKK1
+      api_url=UUUUU1
+      [parameters.bob]
+      api_key=KKKKK2
+      api_url=UUUUU2
+      [parameters.eve]
+      api_key=KKKKK3
+      api_url=UUUUU3
+    ```
+    """
+    return [(name, params) for name, params in config['parameters'].items()
+            if isinstance(params, dict)] or [('default', {})]
+
+
+def prepare_partitions(config: Config, store: t.Optional[Store] = None) -> t.Iterator[Partition]:
+    """Iterate over client parameters, partitioning over `partition_keys`.
+
+    First, this produces a Cartesian-Cross over the range of keys.
+    For example, if the keys were 'year' and 'month', it would produce
+    an iterable like: ( ('2020', '01'), ('2020', '02'), ('2020', '03'), ...)
+
+    If the `parameters` section contains subsections (e.g. '[parameters.1]',
+    '[parameters.2]'), collect a repeating cycle of the subsection key-value
+    pairs. Otherwise, store empty dictionaries.
+
+    This is useful for specifying multiple API keys for your configuration.
+
+    For example:
+    ```
+      [parameters.alice]
+      api_key=KKKKK1
+      api_url=UUUUU1
+      [parameters.bob]
+      api_key=KKKKK2
+      api_url=UUUUU2
+      [parameters.eve]
+      api_key=KKKKK3
+      api_url=UUUUU3
+    ```
+    """
     if store is None:
         store = FSStore()
-    partition_keys = config['parameters']['partition_keys']
+    partition_keys = config.get('parameters', {}).get('partition_keys', [])
     selection = config.get('selection', {})
 
-    # Produce a Cartesian-Cross over the range of keys.
-    # For example, if the keys were 'year' and 'month', it would produce
-    # an iterable like: ( ('2020', '01'), ('2020', '02'), ('2020', '03'), ...)
     fan_out = itertools.product(*[selection[key] for key in partition_keys])
 
-    # If the `parameters` section contains subsections (e.g. '[parameters.1]',
-    # '[parameters.2]'), collect a repeating cycle of the subsection key-value
-    # pairs. Otherwise, store empty dictionaries.
-    #
-    # This is useful for specifying multiple API keys for your configuration.
-    # For example:
-    # ```
-    #   [parameters.deepmind]
-    #   api_key=KKKKK1
-    #   api_url=UUUUU1
-    #   [parameters.research]
-    #   api_key=KKKKK2
-    #   api_url=UUUUU2
-    #   [parameters.cloud]
-    #   api_key=KKKKK3
-    #   api_url=UUUUU3
-    # ```
-    extra_params = [params for _, params in config['parameters'].items() if isinstance(params, dict)]
-    params_loop = itertools.cycle(extra_params) if extra_params else itertools.repeat({})
+    params_loop = itertools.cycle(get_subsections(config))
 
-    def new_downloads_only(candidate: t.Dict) -> bool:
-        """Predicate function to skip already downloaded partitions."""
-        return not skip_partition(candidate, store)
-
-    return zip(
-        filter(new_downloads_only, [_create_partition_config(option, config) for option in fan_out]),
-        params_loop
+    partition_configs = filter(
+        lambda it: new_downloads_only(it, store),
+        (_create_partition_config(option, config) for option in fan_out)
     )
 
+    yield from ((*name_and_params, config) for name_and_params, config in zip(params_loop, partition_configs))
 
-def assemble_partition_config(partition: t.Tuple,
-                              config: t.Dict,
-                              manifest: Manifest) -> t.Dict:
-    """Assemble the configuration for a single partition."""
-    # For each of these 'selection' sections, the output dictionary will
-    # overwrite parameters from the extra param subsections (above),
-    # evenly cycling through each subsection.
-    # For example:
-    #   { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
-    #   { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
-    #   { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
-    #   { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
-    #   { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
-    #   { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
-    #   ...
-    out, params = partition
+
+def new_downloads_only(candidate: t.Dict, store: t.Optional[Store] = None) -> bool:
+    """Predicate function to skip already downloaded partitions."""
+    if store is None:
+        store = FSStore()
+    should_skip = skip_partition(candidate, store)
+    if should_skip:
+        beam.metrics.Metrics.counter('Prepare', 'skipped').inc()
+    return not should_skip
+
+
+def assemble_config(partition: Partition, manifest: Manifest) -> Config:
+    """Assemble the configuration for a single partition.
+
+    For each cross product of the 'selection' sections, the output dictionary
+    will overwrite parameters from the extra param subsections, evenly cycling
+    through each subsection.
+
+    For example:
+      { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
+      ...
+    """
+    name, params, out = partition
     out['parameters'].update(params)
+    out['parameters']['__subsection__'] = name
 
     location = prepare_target_name(out)
     user = out['parameters'].get('user_id', 'unknown')
     manifest.schedule(out['selection'], location, user)
 
-    logger.info(f'Created partition {location!r}.')
+    logger.info(f'[{name}] Created partition {location!r}.')
+    beam.metrics.Metrics.counter('Subsection', name).inc()
+
     return out
-
-
-@retry_with_exponential_backoff
-def upload(store: Store, src: io.FileIO, dest: str) -> None:
-    """Upload blob to cloud storage."""
-    with store.open(dest, 'wb') as dest_:
-        shutil.copyfileobj(src, dest_, WRITE_CHUNK_SIZE)
-
-
-def fetch_data(config: t.Dict,
-               *,
-               client_name: str,
-               manifest: Manifest = NoOpManifest(Location('noop://in-memory')),
-               store: t.Optional[Store] = None) -> None:
-    """Download data from a client to a temp file, then upload to Google Cloud Storage."""
-    if not config:
-        return
-
-    if store is None:
-        store = FSStore()
-
-    client = CLIENTS[client_name](config)
-    target = prepare_target_name(config)
-    dataset = config['parameters'].get('dataset', '')
-    selection = config['selection']
-    user = config['parameters'].get('user_id', 'unknown')
-
-    with manifest.transact(selection, target, user):
-        with tempfile.NamedTemporaryFile() as temp:
-            logger.info(f'Fetching data for {target!r}.')
-            client.retrieve(dataset, selection, temp.name)
-
-            logger.info(f'Uploading to store for {target!r}.')
-            upload(store, temp, target)
-
-            logger.info(f'Upload to store complete for {target!r}.')
 
 
 def run(argv: t.List[str], save_main_session: bool = True):
@@ -311,16 +299,24 @@ def run(argv: t.List[str], save_main_session: bool = True):
         pipeline_options.view_as(StandardOptions).runner = 'DirectRunner'
         manifest = LocalManifest(Location(local_dir))
 
-    pipeline_options = configure_workers(client_name, config, known_args.num_requests_per_key, pipeline_options)
+    num_requesters_per_key = known_args.num_requests_per_key
+    if num_requesters_per_key == -1:
+        num_requesters_per_key = CLIENTS[client_name](config).num_requests_per_key(
+            config.get('parameters', {}).get('dataset', "")
+        )
+
+    request_idxs = {name: itertools.cycle(range(num_requesters_per_key)) for name, _ in get_subsections(config)}
+
+    def subsection_and_request(it: Config) -> t.Tuple[str, int]:
+        subsection = t.cast(str, it.get('parameters', {}).get('__subsection__', 'default'))
+        return subsection, next(request_idxs[subsection])
 
     with beam.Pipeline(options=pipeline_options) as p:
         (
                 p
                 | 'Create' >> beam.Create([config])
                 | 'Prepare' >> beam.FlatMap(prepare_partitions, store=store)
-                # Shuffling here prevents beam from fusing all steps,
-                # which would result in utilizing only a single worker.
-                | 'Shuffle' >> beam.Reshuffle()
-                | 'Partition' >> beam.Map(assemble_partition_config, config=config, manifest=manifest)
-                | 'FetchData' >> beam.Map(fetch_data, client_name=client_name, manifest=manifest, store=store)
+                | 'Assemble' >> beam.Map(assemble_config, manifest=manifest)
+                | 'GroupBy' >> beam.GroupBy(subsection_and_request)
+                | 'FetchData' >> beam.ParDo(Fetcher(client_name, manifest, store))
         )

--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -16,12 +16,9 @@ import unittest
 from collections import OrderedDict
 from unittest.mock import MagicMock
 
-from apache_beam.options.pipeline_options import PipelineOptions
-
 from .manifest import MockManifest, Location
 from .pipeline import (
     assemble_config,
-    configure_workers,
     prepare_partitions,
     skip_partition,
 )
@@ -37,125 +34,6 @@ class OddFilesDoNotExistStore(InMemoryStore):
         ret = self.count % 2 == 0
         self.count += 1
         return ret
-
-
-class ConfigureWorkersTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.config = {
-            'parameters': {
-                'partition_keys': ['year'],
-                'target_path': 'download-{}.nc',
-                'num_api_keys': 1
-            },
-            'selection': {
-                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
-                'month': [str(i) for i in range(1, 13)],
-                'year': [str(i) for i in range(2015, 2021)]
-            }
-        }
-
-    def test_fake_client(self):
-        opts = configure_workers('fake', self.config, -1, PipelineOptions([]))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 1,
-            'num_workers': 1,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_multiple_api_keys(self):
-        self.config['parameters']['num_api_keys'] = 4
-        opts = configure_workers('fake', self.config, -1, PipelineOptions([]))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 2,
-            'num_workers': 2,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_multiple_api_keys__rounds_up(self):
-        self.config['parameters']['num_api_keys'] = 5
-        opts = configure_workers('fake', self.config, -1, PipelineOptions([]))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 3,
-            'num_workers': 3,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_user_specifies_requestors(self):
-        opts = configure_workers('fake', self.config, 3, PipelineOptions([]))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 2,
-            'num_workers': 2,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_user_specifies_threads(self):
-        args = '--number_of_worker_harness_threads 3 --experiments use_runner_v2'.split()
-        self.config['parameters']['num_api_keys'] = 15
-        opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 3,
-            'max_num_workers': 5,
-            'num_workers': 5,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_user_specifies_threads__rounds_up(self):
-        args = '--number_of_worker_harness_threads 3 --experiments use_runner_v2'.split()
-        self.config['parameters']['num_api_keys'] = 17
-        opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 3,
-            'max_num_workers': 6,
-            'num_workers': 6,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_user_specifies_workers(self):
-        args = '--max_num_workers 3'.split()
-        self.config['parameters']['num_api_keys'] = 6
-        opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 3,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_user_specifies_workers__rounds_up(self):
-        args = '--max_num_workers 3'.split()
-        self.config['parameters']['num_api_keys'] = 7
-        opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 3,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
-
-    def test_user_specifies_workers__large(self):
-        args = '--max_num_workers 12'.split()
-        self.config['parameters']['num_api_keys'] = 7
-        with self.assertWarnsRegex(
-                Warning,
-                "Max number of workers 12 with 2 threads each exceeds recommended 7 concurrent requests."
-        ):
-            opts = configure_workers('fake', self.config, -1, PipelineOptions(args))
-        expected = {
-            'experiments': ['use_runner_v2'],
-            'number_of_worker_harness_threads': 2,
-            'max_num_workers': 12,
-        }
-        self.assertEqual(expected, opts.get_all_options(drop_default=True))
 
 
 class PreparePartitionTest(unittest.TestCase):

--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -11,27 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import io
-import socket
-import tempfile
 import typing as t
 import unittest
 from collections import OrderedDict
-from unittest.mock import patch, ANY, MagicMock
+from unittest.mock import MagicMock
 
 from apache_beam.options.pipeline_options import PipelineOptions
 
 from .manifest import MockManifest, Location
 from .pipeline import (
-    assemble_partition_config,
+    assemble_config,
     configure_workers,
-    fetch_data,
     prepare_partitions,
-    prepare_target_name,
     skip_partition,
-    upload,
 )
-from .stores import InMemoryStore, Store, FSStore
+from .stores import InMemoryStore, Store
 
 
 class OddFilesDoNotExistStore(InMemoryStore):
@@ -172,7 +166,7 @@ class PreparePartitionTest(unittest.TestCase):
     def create_partition_configs(self, config, store: t.Optional[Store] = None) -> t.List[t.Dict]:
         partition_list = prepare_partitions(config, store=store)
         return [
-            assemble_partition_config(p, config, manifest=self.dummy_manifest)
+            assemble_config(p, manifest=self.dummy_manifest)
             for p in partition_list
         ]
 
@@ -245,24 +239,26 @@ class PreparePartitionTest(unittest.TestCase):
 
         actual = self.create_partition_configs(config)
 
-        self.assertListEqual(actual, [
-            {'parameters': OrderedDict(config['parameters'], api_key='KKKK1',
-                                       api_url='UUUU1'),
+        expected = [
+            {'parameters': OrderedDict(config['parameters'], api_key='KKKK1', api_url='UUUU1',
+                                       __subsection__='research'),
              'selection': {**config['selection'],
                            **{'year': ['2015'], 'month': ['1']}}},
-            {'parameters': OrderedDict(config['parameters'], api_key='KKKK2',
-                                       api_url='UUUU2'),
+            {'parameters': OrderedDict(config['parameters'], api_key='KKKK2', api_url='UUUU2',
+                                       __subsection__='cloud'),
              'selection': {**config['selection'],
                            **{'year': ['2015'], 'month': ['2']}}},
-            {'parameters': OrderedDict(config['parameters'], api_key='KKKK3',
-                                       api_url='UUUU3'),
+            {'parameters': OrderedDict(config['parameters'], api_key='KKKK3', api_url='UUUU3',
+                                       __subsection__='deepmind'),
              'selection': {**config['selection'],
                            **{'year': ['2016'], 'month': ['1']}}},
-            {'parameters': OrderedDict(config['parameters'], api_key='KKKK1',
-                                       api_url='UUUU1'),
+            {'parameters': OrderedDict(config['parameters'], api_key='KKKK1', api_url='UUUU1',
+                                       __subsection__='research'),
              'selection': {**config['selection'],
                            **{'year': ['2016'], 'month': ['2']}}},
-        ])
+        ]
+
+        self.assertListEqual(actual, expected)
 
     def test_prepare_partition_records_download_status_to_manifest(self):
         config = {
@@ -316,189 +312,6 @@ class PreparePartitionTest(unittest.TestCase):
         cloud_configs = [cfg for cfg in actual if cfg and cfg['parameters']['api_url'].endswith('2')]
 
         self.assertEqual(len(research_configs), len(cloud_configs))
-
-
-class UploadTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.message = b'the quick brown fox jumped over the lazy dog'.split()
-        self.store = FSStore()
-
-    def test_upload_writes_to_store(self):
-        with tempfile.NamedTemporaryFile() as src:
-            src.writelines(self.message)
-            src.flush()
-            src.seek(0)
-            with tempfile.NamedTemporaryFile('wb') as dst:
-                upload(self.store, src, dst.name)
-                with open(dst.name, 'rb') as dst1:
-                    self.assertEqual(dst1.readlines()[0], b''.join(self.message))
-
-    def test_retries_after_socket_timeout_error(self):
-        class SocketTimeoutStore(InMemoryStore):
-            count = 0
-
-            def open(self, filename: str, mode: str = 'r') -> t.IO:
-                self.count += 1
-                raise socket.timeout('Deliberate error.')
-
-        socket_store = SocketTimeoutStore()
-
-        with tempfile.NamedTemporaryFile() as src:
-            src.writelines(self.message)
-            src.flush()
-            with tempfile.NamedTemporaryFile('wb') as dst:
-                with self.assertRaises(socket.timeout):
-                    upload(socket_store, src, dst.name)
-        self.assertEqual(socket_store.count, 8)
-
-
-class FetchDataTest(unittest.TestCase):
-
-    def setUp(self) -> None:
-        self.dummy_manifest = MockManifest(Location('dummy-manifest'))
-
-    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
-    @patch('cdsapi.Client.retrieve')
-    def test_fetch_data(self, mock_retrieve, mock_gcs_file):
-        config = {
-            'parameters': {
-                'dataset': 'reanalysis-era5-pressure-levels',
-                'partition_keys': ['year', 'month'],
-                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
-                'api_url': 'https//api-url.com/v1/',
-                'api_key': '12345',
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['01']
-            }
-        }
-
-        fetch_data(config, client_name='cds', manifest=self.dummy_manifest,
-                   store=InMemoryStore())
-
-        mock_gcs_file.assert_called_with(
-            'gs://weather-dl-unittest/download-01-12.nc',
-            'wb'
-        )
-
-        mock_retrieve.assert_called_with(
-            'reanalysis-era5-pressure-levels',
-            config['selection'],
-            ANY)
-
-    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
-    @patch('cdsapi.Client.retrieve')
-    def test_fetch_data__manifest__returns_success(self, mock_retrieve, mock_gcs_file):
-        config = {
-            'parameters': {
-                'dataset': 'reanalysis-era5-pressure-levels',
-                'partition_keys': ['year', 'month'],
-                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
-                'api_url': 'https//api-url.com/v1/',
-                'api_key': '12345',
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['01']
-            }
-        }
-
-        fetch_data(config, client_name='cds', manifest=self.dummy_manifest,
-                   store=InMemoryStore())
-
-        self.assertDictContainsSubset(dict(
-            selection=config['selection'],
-            location='gs://weather-dl-unittest/download-01-12.nc',
-            status='success',
-            error=None,
-            user='unknown',
-        ), list(self.dummy_manifest.records.values())[0]._asdict())
-
-    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
-    @patch('cdsapi.Client.retrieve')
-    def test_fetch_data__manifest__records_retrieve_failure(self, mock_retrieve,
-                                                            mock_gcs_file):
-        config = {
-            'parameters': {
-                'dataset': 'reanalysis-era5-pressure-levels',
-                'partition_keys': ['year', 'month'],
-                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
-                'api_url': 'https//api-url.com/v1/',
-                'api_key': '12345',
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['01']
-            }
-        }
-
-        error = IOError("We don't have enough permissions to download this.")
-        mock_retrieve.side_effect = error
-
-        with self.assertRaises(IOError) as e:
-            fetch_data(
-                config,
-                client_name='cds',
-                manifest=self.dummy_manifest,
-                store=InMemoryStore()
-            )
-
-            actual = list(self.dummy_manifest.records.values())[0]._asdict()
-
-            self.assertDictContainsSubset(dict(
-                selection=config['selection'],
-                location='gs://weather-dl-unittest/download-01-12.nc',
-                status='failure',
-                user='unknown',
-            ), actual)
-
-            self.assertIn(error.args[0], actual['error'])
-            self.assertIn(error.args[0], e.exception.args[0])
-
-    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
-    @patch('cdsapi.Client.retrieve')
-    def test_fetch_data__manifest__records_gcs_failure(self, mock_retrieve,
-                                                       mock_gcs_file):
-        config = {
-            'parameters': {
-                'dataset': 'reanalysis-era5-pressure-levels',
-                'partition_keys': ['year', 'month'],
-                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
-                'api_url': 'https//api-url.com/v1/',
-                'api_key': '12345',
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['01']
-            }
-        }
-
-        error = IOError("Can't open gcs file.")
-        mock_gcs_file.side_effect = error
-
-        with self.assertRaises(IOError) as e:
-            fetch_data(
-                config,
-                client_name='cds',
-                manifest=self.dummy_manifest,
-                store=InMemoryStore()
-            )
-
-            actual = list(self.dummy_manifest.records.values())[0]._asdict()
-            self.assertDictContainsSubset(dict(
-                selection=config['selection'],
-                location='gs://weather-dl-unittest/download-01-12.nc',
-                status='failure',
-                user='unknown',
-            ), actual)
-
-            self.assertIn(error.args[0], actual['error'])
-            self.assertIn(error.args[0], e.exception.args[0])
 
 
 class SkipPartitionsTest(unittest.TestCase):
@@ -560,113 +373,6 @@ class SkipPartitionsTest(unittest.TestCase):
         actual = skip_partition(config, self.mock_store)
 
         self.assertEqual(actual, True)
-
-
-class PrepareTargetNameTest(unittest.TestCase):
-
-    def setUp(self) -> None:
-        self.dummy_manifest = MockManifest(Location('dummy-manifest'))
-
-    def test_target_name_no_date(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['year', 'month'],
-                'target_path': 'download-{}-{}.nc',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['02']
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "download-02-12.nc")
-
-    def test_target_name_date_no_target_directory(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date'],
-                'target_path': 'download-{}.nc',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'date': ['2017-01-15'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "download-2017-01-15.nc")
-
-    def test_target_name_target_directory_no_date(self):
-        config = {
-            'parameters': {
-                'target_path': 'somewhere/',
-                'partition_keys': ['year', 'month'],
-                'target_filename': 'download/{}/{}.nc',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'month': ['12'],
-                'year': ['02']
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/download/02/12.nc")
-
-    def test_target_name_date_and_target_directory(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date'],
-                'target_path': 'somewhere',
-                'target_filename': '-download.nc',
-                'append_date_dirs': 'true',
-                'force_download': False
-            },
-            'selection': {
-                'date': ['2017-01-15'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/2017/01/15-download.nc")
-
-    def test_target_name_date_and_target_directory_additional_partitions(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date', 'pressure_level'],
-                'target_path': 'somewhere',
-                'target_filename': '-pressure-{}.nc',
-                'append_date_dirs': 'true',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'pressure_level': ['500'],
-                'date': ['2017-01-15'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/2017/01/15-pressure-500.nc")
-
-    def test_target_name_date_and_target_directory_additional_partitions_in_path(self):
-        config = {
-            'parameters': {
-                'partition_keys': ['date', 'expver', 'pressure_level'],
-                'target_path': 'somewhere/expver-{}',
-                'target_filename': '-pressure-{}.nc',
-                'append_date_dirs': 'true',
-                'force_download': False
-            },
-            'selection': {
-                'features': ['pressure'],
-                'pressure_level': ['500'],
-                'date': ['2017-01-15'],
-                'expver': ['1'],
-            }
-        }
-        target_name = prepare_target_name(config)
-        self.assertEqual(target_name, "somewhere/expver-1/2017/01/15-pressure-500.nc")
 
 
 if __name__ == '__main__':

--- a/weather_dl/setup.py
+++ b/weather_dl/setup.py
@@ -32,7 +32,7 @@ base_requirements = [
 setup(
     name='download_pipeline',
     packages=find_packages(),
-    version='0.1.1',
+    version='0.1.2',
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
     url='https://weather-tools.readthedocs.io/en/latest/weather_dl/',


### PR DESCRIPTION
In this change, I divide up the download requets to workers in a data-driven way. Namely, after fanning out the partitions, I group by both the license and number of requests. Then, I've restructured the fetch step to execute each group of configs in order.

This way, we can guarantee that all licenses are being utilized to their max capacity and within rate limits. This is a much better fix for #98, as it also obviates the needs to limit the max number of workers (this is actually autoscale friendly!)

Thanks to zyda@google.com for the idea and an example for how to implement this.