### PR TITLE
Downloader refactor: extracted out partitioning; tested pipeline args.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,11 @@ jobs:
     - name: Install weather-tools
       run: |
         pip install -e .[test]
+    - name: Run unit tests
+      run: pytest
       env:
         - CDSAPI_URL: https://cds.climate.copernicus.eu/api/v2
         - CDSAPI_KEY: 12345:1234567-ab12-34cd-9876-4o4fake90909  # A fake key for testing
-    - name: Run unit tests
-      run: pytest
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  CDSAPI_URL: https://cds.climate.copernicus.eu/api/v2
+  CDSAPI_KEY: 12345:1234567-ab12-34cd-9876-4o4fake90909  # A fake key for testing
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -59,9 +63,6 @@ jobs:
         pip install -e .[test]
     - name: Run unit tests
       run: pytest
-      env:
-        - CDSAPI_URL: https://cds.climate.copernicus.eu/api/v2
-        - CDSAPI_KEY: 12345:1234567-ab12-34cd-9876-4o4fake90909  # A fake key for testing
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Install weather-tools
       run: |
         pip install -e .[test]
+      env:
+        - CDSAPI_URL: https://cds.climate.copernicus.eu/api/v2
+        - CDSAPI_KEY: 12345:1234567-ab12-34cd-9876-4o4fake90909  # A fake key for testing
     - name: Run unit tests
       run: pytest
   lint:

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ test_requirements = [
     "netcdf4",
     "numpy",
     "xarray",
+    "xarray-beam",
+    "absl-py",
 ]
 
 all_test_requirements = weather_dl_requirements + weather_mv_requirements + weather_sp_requirements + test_requirements

--- a/weather_dl/download_pipeline/__init__.py
+++ b/weather_dl/download_pipeline/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .pipeline import run
+from .pipeline import run, pipeline
 
 
 def cli(extra=[]):
     import sys
-    run(sys.argv + extra)
+    pipeline(run(sys.argv + extra))

--- a/weather_dl/download_pipeline/partition.py
+++ b/weather_dl/download_pipeline/partition.py
@@ -1,0 +1,188 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy as cp
+import dataclasses
+import itertools
+import logging
+import typing as t
+
+import apache_beam as beam
+
+from .manifest import Manifest
+from .parsers import Config, prepare_target_name
+from .stores import Store, FSStore
+
+Partition = t.Tuple[str, t.Dict, Config]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class PartitionConfig(beam.PTransform):
+    """Partition a config into multiple data requests.
+
+    Partitioning involves four main operations: First, we fan-out shards based on
+    partition keys (a cross product of the values). Second, we filter out existing
+    downloads (unless we want to force downloads). Next, we add subsections to the
+    configs in a cycle (to ensure an even distribution of extra parameters). Last,
+    We assemble each partition into a single Config.
+
+    Attributes:
+        store: A cloud storage system, used for checking the existence of downloads.
+        subsections: A cycle of (name, parameter) tuples.
+        manifest: A download manifest to register preparation state.
+    """
+
+    store: Store
+    subsections: itertools.cycle
+    manifest: Manifest
+
+    def expand(self, configs):
+        def loop_through_subsections(it: Config) -> Partition:
+            """Assign a subsection to each config in a loop.
+
+            If the `parameters` section contains subsections (e.g. '[parameters.1]',
+            '[parameters.2]'), collect a repeating cycle of the subsection key-value
+            pairs. Otherwise, assign a default section to each config.
+
+            This is useful for specifying multiple API keys for your configuration.
+
+            For example:
+            ```
+              [parameters.alice]
+              api_key=KKKKK1
+              api_url=UUUUU1
+              [parameters.bob]
+              api_key=KKKKK2
+              api_url=UUUUU2
+              [parameters.eve]
+              api_key=KKKKK3
+              api_url=UUUUU3
+            ```
+            """
+            name, params = next(self.subsections)
+            return name, params, it
+
+        return (
+                configs
+                | 'Prepare partitions' >> beam.FlatMap(prepare_partitions)
+                | 'Skip existing downloads' >> beam.Filter(new_downloads_only, store=self.store)
+                | 'Cycle through subsections' >> beam.Map(loop_through_subsections)
+                | 'Assemble the data request' >> beam.Map(assemble_config, manifest=self.manifest)
+        )
+
+
+def _create_partition_config(option: t.Tuple, config: Config) -> Config:
+    """Create a config for a single partition option.
+
+    Output a config dictionary, overriding the range of values for
+    each key with the partition instance in 'selection'.
+    Continuing the example from prepare_partitions, the selection section
+    would be:
+      { 'foo': ..., 'year': ['2020'], 'month': ['01'], ... }
+      { 'foo': ..., 'year': ['2020'], 'month': ['02'], ... }
+      { 'foo': ..., 'year': ['2020'], 'month': ['03'], ... }
+
+    Args:
+        option: A single item in the range of partition_keys.
+        config: The download config, including the parameters and selection sections.
+
+    Returns:
+        A configuration with that selects a single download partition.
+    """
+    partition_keys = config.get('parameters', {}).get('partition_keys', [])
+    selection = config.get('selection', {})
+    copy = cp.deepcopy(selection)
+    out = cp.deepcopy(config)
+    for idx, key in enumerate(partition_keys):
+        copy[key] = [option[idx]]
+
+    out['selection'] = copy
+    return out
+
+
+def skip_partition(config: Config, store: Store) -> bool:
+    """Return true if partition should be skipped."""
+
+    if config['parameters'].get('force_download', False):
+        return False
+
+    target = prepare_target_name(config)
+    if store.exists(target):
+        logger.info(f'file {target} found, skipping.')
+        return True
+
+    return False
+
+
+def prepare_partitions(config: Config) -> t.Iterator[Config]:
+    """Iterate over client parameters, partitioning over `partition_keys`.
+
+    This produces a Cartesian-Cross over the range of keys.
+
+    For example, if the keys were 'year' and 'month', it would produce
+    an iterable like:
+        ( ('2020', '01'), ('2020', '02'), ('2020', '03'), ...)
+
+    Returns:
+        An iterator of `Config`s.
+    """
+    partition_keys = config.get('parameters', {}).get('partition_keys', [])
+    selection = config.get('selection', {})
+
+    for option in itertools.product(*[selection[key] for key in partition_keys]):
+        yield _create_partition_config(option, config)
+
+
+def new_downloads_only(candidate: Config, store: t.Optional[Store] = None) -> bool:
+    """Predicate function to skip already downloaded partitions."""
+    if store is None:
+        store = FSStore()
+    should_skip = skip_partition(candidate, store)
+    if should_skip:
+        beam.metrics.Metrics.counter('Prepare', 'skipped').inc()
+    return not should_skip
+
+
+def assemble_config(partition: Partition, manifest: Manifest) -> Config:
+    """Assemble the configuration for a single partition.
+
+    For each cross product of the 'selection' sections, the output dictionary
+    will overwrite parameters from the extra param subsections, evenly cycling
+    through each subsection.
+
+    For example:
+      { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
+      { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
+      ...
+
+    Returns:
+        An `Config` assembled out of subsection parameters and config shards.
+    """
+    name, params, out = partition
+    out['parameters'].update(params)
+    out['parameters']['__subsection__'] = name
+
+    location = prepare_target_name(out)
+    user = out['parameters'].get('user_id', 'unknown')
+    manifest.schedule(out['selection'], location, user)
+
+    logger.info(f'[{name}] Created partition {location!r}.')
+    beam.metrics.Metrics.counter('Subsection', name).inc()
+
+    return out

--- a/weather_dl/download_pipeline/partition_test.py
+++ b/weather_dl/download_pipeline/partition_test.py
@@ -1,0 +1,262 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+import json
+import tempfile
+import typing as t
+import unittest
+from unittest.mock import MagicMock
+
+import apache_beam as beam
+from xarray_beam._src.test_util import EagerPipeline
+
+from .manifest import MockManifest, Location, LocalManifest
+from .parsers import get_subsections
+from .partition import skip_partition, PartitionConfig
+from .stores import InMemoryStore, Store
+
+
+class OddFilesDoNotExistStore(InMemoryStore):
+    def __init__(self):
+        super().__init__()
+        self.count = 0
+
+    def exists(self, filename: str) -> bool:
+        ret = self.count % 2 == 0
+        self.count += 1
+        return ret
+
+
+class PreparePartitionTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.dummy_manifest = MockManifest(Location('mock://dummy'))
+
+    def create_partition_configs(self, config, store: t.Optional[Store] = None) -> t.List[t.Dict]:
+        subsections = get_subsections(config)
+        params_cycle = itertools.cycle(subsections)
+
+        return (EagerPipeline()
+                | beam.Create([config])
+                | PartitionConfig(store, params_cycle, self.dummy_manifest))
+
+    def test_partition_single_key(self):
+        config = {
+            'parameters': {
+                'partition_keys': ['year'],
+                'target_path': 'download-{}.nc',
+            },
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 13)],
+                'year': [str(i) for i in range(2015, 2021)]
+            }
+        }
+
+        actual = self.create_partition_configs(config)
+
+        self.assertListEqual([d['selection'] for d in actual], [
+            {**config['selection'], **{'year': [str(i)]}}
+            for i in range(2015, 2021)
+        ])
+
+    def test_partition_multi_key(self):
+        config = {
+            'parameters': {
+                'partition_keys': ['year', 'month'],
+                'target_path': 'download-{}-{}.nc',
+            },
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 3)],
+                'year': [str(i) for i in range(2015, 2017)]
+            }
+        }
+
+        actual = self.create_partition_configs(config)
+
+        self.assertListEqual([d['selection'] for d in actual], [
+            {**config['selection'], **{'year': ['2015'], 'month': ['1']}},
+            {**config['selection'], **{'year': ['2015'], 'month': ['2']}},
+            {**config['selection'], **{'year': ['2016'], 'month': ['1']}},
+            {**config['selection'], **{'year': ['2016'], 'month': ['2']}},
+        ])
+
+    def test_partition_multi_params_multi_key(self):
+        config = {
+            'parameters': dict(
+                partition_keys=['year', 'month'],
+                target_path='download-{}-{}.nc',
+                research={
+                    'api_key': 'KKKK1',
+                    'api_url': 'UUUU1'
+                },
+                cloud={
+                    'api_key': 'KKKK2',
+                    'api_url': 'UUUU2'
+                },
+                deepmind={
+                    'api_key': 'KKKK3',
+                    'api_url': 'UUUU3'
+                }
+            ),
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 3)],
+                'year': [str(i) for i in range(2015, 2017)]
+            }
+        }
+
+        actual = self.create_partition_configs(config)
+
+        expected = [
+            {'parameters': dict(config['parameters'], api_key='KKKK1', api_url='UUUU1', __subsection__='research'),
+             'selection': {**config['selection'],
+                           **{'year': ['2015'], 'month': ['1']}}},
+            {'parameters': dict(config['parameters'], api_key='KKKK2', api_url='UUUU2', __subsection__='cloud'),
+             'selection': {**config['selection'],
+                           **{'year': ['2015'], 'month': ['2']}}},
+            {'parameters': dict(config['parameters'], api_key='KKKK3', api_url='UUUU3', __subsection__='deepmind'),
+             'selection': {**config['selection'],
+                           **{'year': ['2016'], 'month': ['1']}}},
+            {'parameters': dict(config['parameters'], api_key='KKKK1', api_url='UUUU1', __subsection__='research'),
+             'selection': {**config['selection'],
+                           **{'year': ['2016'], 'month': ['2']}}},
+        ]
+
+        self.assertListEqual(actual, expected)
+
+    def test_prepare_partition_records_download_status_to_manifest(self):
+        config = {
+            'parameters': {
+                'partition_keys': ['year'],
+                'target_path': 'download-{}.nc',
+            },
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 13)],
+                'year': [str(i) for i in range(2015, 2021)]
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.dummy_manifest = LocalManifest(Location(tmpdir))
+
+            self.create_partition_configs(config)
+
+            with open(self.dummy_manifest.location, 'r') as f:
+                actual = json.load(f)
+
+            self.assertListEqual(
+                [d['selection'] for d in actual.values()], [
+                    {**config['selection'], **{'year': [str(i)]}}
+                    for i in range(2015, 2021)
+                ])
+
+            self.assertTrue(
+                all([d['status'] == 'scheduled' for d in actual.values()])
+            )
+
+    def test_skip_partitions__never_unbalances_licenses(self):
+        skip_odd_files = OddFilesDoNotExistStore()
+        config = {
+            'parameters': dict(
+                partition_keys=['year', 'month'],
+                target_path='download-{}-{}.nc',
+                research={
+                    'api_key': 'KKKK1',
+                    'api_url': 'UUUU1'
+                },
+                cloud={
+                    'api_key': 'KKKK2',
+                    'api_url': 'UUUU2'
+                }
+            ),
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 3)],
+                'year': [str(i) for i in range(2016, 2020)]
+            }
+        }
+
+        actual = self.create_partition_configs(config, store=skip_odd_files)
+        research_configs = [cfg for cfg in actual if cfg and cfg['parameters']['api_url'].endswith('1')]
+        cloud_configs = [cfg for cfg in actual if cfg and cfg['parameters']['api_url'].endswith('2')]
+
+        self.assertEqual(len(research_configs), len(cloud_configs))
+
+
+class SkipPartitionsTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.mock_store = InMemoryStore()
+
+    def test_skip_partition_missing_force_download(self):
+        config = {
+            'parameters': {
+                'partition_keys': ['year', 'month'],
+                'target_path': 'download-{}-{}.nc',
+            },
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 13)],
+                'year': [str(i) for i in range(2015, 2021)]
+            }
+        }
+
+        actual = skip_partition(config, self.mock_store)
+
+        self.assertEqual(actual, False)
+
+    def test_skip_partition_force_download_true(self):
+        config = {
+            'parameters': {
+                'partition_keys': ['year', 'month'],
+                'target_path': 'download-{}-{}.nc',
+                'force_download': True
+            },
+            'selection': {
+                'features': ['pressure', 'temperature', 'wind_speed_U', 'wind_speed_V'],
+                'month': [str(i) for i in range(1, 13)],
+                'year': [str(i) for i in range(2015, 2021)]
+            }
+        }
+
+        actual = skip_partition(config, self.mock_store)
+
+        self.assertEqual(actual, False)
+
+    def test_skip_partition_force_download_false(self):
+        config = {
+            'parameters': {
+                'partition_keys': ['year', 'month'],
+                'target_path': 'download-{}-{}.nc',
+                'force_download': False
+            },
+            'selection': {
+                'features': ['pressure'],
+                'month': ['12'],
+                'year': ['02']
+            }
+        }
+
+        self.mock_store.exists = MagicMock(return_value=True)
+
+        actual = skip_partition(config, self.mock_store)
+
+        self.assertEqual(actual, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Primary ECMWF Downloader Workflow."""
 import argparse
-import copy as cp
+import dataclasses
 import getpass
 import itertools
 import logging
@@ -29,18 +29,21 @@ from apache_beam.options.pipeline_options import (
 
 from .clients import CLIENTS
 from .fetcher import Fetcher
-from .manifest import Manifest, Location, NoOpManifest, LocalManifest
+from .manifest import (
+    Location,
+    LocalManifest,
+    Manifest,
+    NoOpManifest,
+)
 from .parsers import (
     Config,
-    parse_manifest_location,
-    prepare_target_name,
-    process_config,
+    parse_manifest,
+    process_config, get_subsections,
 )
-from .stores import Store, TempFileStore, FSStore, LocalFileStore
+from .partition import PartitionConfig
+from .stores import TempFileStore, LocalFileStore
 
 logger = logging.getLogger(__name__)
-
-Partition = t.Tuple[str, t.Dict, Config]
 
 
 def configure_logger(verbosity: int) -> None:
@@ -50,137 +53,59 @@ def configure_logger(verbosity: int) -> None:
     logger.setLevel(level)
 
 
-def _create_partition_config(option: t.Tuple, config: Config) -> Config:
-    """Create a config for a single partition option.
+@dataclasses.dataclass
+class PipelineArgs:
+    """Options for download pipeline.
 
-    Output a config dictionary, overriding the range of values for
-    each key with the partition instance in 'selection'.
-    Continuing the example from prepare_partitions, the selection section
-    would be:
-      { 'foo': ..., 'year': ['2020'], 'month': ['01'], ... }
-      { 'foo': ..., 'year': ['2020'], 'month': ['02'], ... }
-      { 'foo': ..., 'year': ['2020'], 'month': ['03'], ... }
-
-    Args:
-        option: A single item in the range of partition_keys.
-        config: The download config, including the parameters and selection sections.
-
-    Returns:
-        A configuration with that selects a single download partition.
+    Attributes:
+        known_args: Parsed arguments. Includes user-defined args and defaults.
+        pipeline_options: The apache_beam pipeline options.
+        config: The download config / data request.
+        client_name: The type of download client (e.g. Copernicus, Mars, or a fake).
+        store: A Store, which is responsible for where downloads end up.
+        manifest: A Manifest, which records download progress.
+        subsections: A
     """
-    partition_keys = config.get('parameters', {}).get('partition_keys', [])
-    selection = config.get('selection', {})
-    copy = cp.deepcopy(selection)
-    out = cp.deepcopy(config)
-    for idx, key in enumerate(partition_keys):
-        copy[key] = [option[idx]]
-
-    out['selection'] = copy
-    return out
+    known_args: argparse.Namespace
+    pipeline_options: PipelineOptions
+    config: Config
+    client_name: str
+    store: None
+    manifest: Manifest
+    num_requesters_per_key: int
 
 
-def skip_partition(config: Config, store: Store) -> bool:
-    """Return true if partition should be skipped."""
+def pipeline(args: PipelineArgs) -> None:
+    """Main pipeline entrypoint."""
+    logger.info(f"Using '{args.num_requesters_per_key}' requests per subsection (license).")
 
-    if config['parameters'].get('force_download', False):
-        return False
+    subsections = get_subsections(args.config)
 
-    target = prepare_target_name(config)
-    if store.exists(target):
-        logger.info(f'file {target} found, skipping.')
-        return True
+    request_idxs = {name: itertools.cycle(range(args.num_requesters_per_key)) for name, _ in subsections}
 
-    return False
+    def subsection_and_request(it: Config) -> t.Tuple[str, int]:
+        subsection = t.cast(str, it.get('parameters', {}).get('__subsection__', 'default'))
+        return subsection, next(request_idxs[subsection])
 
+    subsections_cycle = itertools.cycle(subsections)
 
-def get_subsections(config: t.Dict) -> t.List[t.Tuple[str, t.Dict]]:
-    """Collect parameter subsections from main configuration.
-
-    If the `parameters` section contains subsections (e.g. '[parameters.1]',
-    '[parameters.2]'), collect the subsection key-value pairs. Otherwise,
-    return an empty dictionary (i.e. there are no subsections).
-
-    This is useful for specifying multiple API keys for your configuration.
-    For example:
-    ```
-      [parameters.alice]
-      api_key=KKKKK1
-      api_url=UUUUU1
-      [parameters.bob]
-      api_key=KKKKK2
-      api_url=UUUUU2
-      [parameters.eve]
-      api_key=KKKKK3
-      api_url=UUUUU3
-    ```
-    """
-    return [(name, params) for name, params in config['parameters'].items()
-            if isinstance(params, dict)] or [('default', {})]
+    with beam.Pipeline(options=args.pipeline_options) as p:
+        (
+                p
+                | 'Create the initial config' >> beam.Create([args.config])
+                | 'Prepare Partitions' >> PartitionConfig(args.store, subsections_cycle, args.manifest)
+                | 'GroupBy request limits' >> beam.GroupBy(subsection_and_request)
+                | 'Fetch data' >> beam.ParDo(Fetcher(args.client_name, args.manifest, args.store))
+        )
 
 
-def prepare_partitions(config: Config) -> t.Iterator[Config]:
-    """Iterate over client parameters, partitioning over `partition_keys`.
-
-    This produces a Cartesian-Cross over the range of keys.
-
-    For example, if the keys were 'year' and 'month', it would produce
-    an iterable like:
-        ( ('2020', '01'), ('2020', '02'), ('2020', '03'), ...)
-    """
-    partition_keys = config.get('parameters', {}).get('partition_keys', [])
-    selection = config.get('selection', {})
-
-    for option in itertools.product(*[selection[key] for key in partition_keys]):
-        yield _create_partition_config(option, config)
-
-
-def new_downloads_only(candidate: Config, store: t.Optional[Store] = None) -> bool:
-    """Predicate function to skip already downloaded partitions."""
-    if store is None:
-        store = FSStore()
-    should_skip = skip_partition(candidate, store)
-    if should_skip:
-        beam.metrics.Metrics.counter('Prepare', 'skipped').inc()
-    return not should_skip
-
-
-def assemble_config(partition: Partition, manifest: Manifest) -> Config:
-    """Assemble the configuration for a single partition.
-
-    For each cross product of the 'selection' sections, the output dictionary
-    will overwrite parameters from the extra param subsections, evenly cycling
-    through each subsection.
-
-    For example:
-      { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
-      { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
-      { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
-      { 'parameters': {... 'api_key': KKKKK1, ... }, ... }
-      { 'parameters': {... 'api_key': KKKKK2, ... }, ... }
-      { 'parameters': {... 'api_key': KKKKK3, ... }, ... }
-      ...
-    """
-    name, params, out = partition
-    out['parameters'].update(params)
-    out['parameters']['__subsection__'] = name
-
-    location = prepare_target_name(out)
-    user = out['parameters'].get('user_id', 'unknown')
-    manifest.schedule(out['selection'], location, user)
-
-    logger.info(f'[{name}] Created partition {location!r}.')
-    beam.metrics.Metrics.counter('Subsection', name).inc()
-
-    return out
-
-
-def run(argv: t.List[str], save_main_session: bool = True):
-    """Main entrypoint & pipeline definition."""
+def run(argv: t.List[str], save_main_session: bool = True) -> PipelineArgs:
+    """Parse user arguments and configure the pipeline."""
     parser = argparse.ArgumentParser(
         prog='weather-dl',
         description='Weather Downloader ingests weather data to cloud storage.'
     )
-    parser.add_argument('config', type=argparse.FileType('r', encoding='utf-8'),
+    parser.add_argument('config', type=str,
                         help="path/to/config.cfg, containing client and data information. "
                              "Accepts *.cfg and *.json files.")
     parser.add_argument('-f', '--force-download', action="store_true", default=False,
@@ -203,7 +128,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
     configure_logger(3)  # 0 = error, 1 = warn, 2 = info, 3 = debug
 
     config = {}
-    with known_args.config as f:
+    with open(known_args.config, 'r', encoding='utf-8') as f:
         config = process_config(f)
 
     config['parameters']['force_download'] = known_args.force_download
@@ -217,8 +142,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
     client_name = config['parameters']['client']
     store = None  # will default to using FileSystems()
     config['parameters']['force_download'] = known_args.force_download
-    manifest = parse_manifest_location(known_args.manifest_location, pipeline_options.get_all_options())
-    subsections = get_subsections(config)
+    manifest = parse_manifest(known_args.manifest_location, pipeline_options.get_all_options())
 
     if known_args.dry_run:
         client_name = 'fake'
@@ -238,49 +162,6 @@ def run(argv: t.List[str], save_main_session: bool = True):
             config.get('parameters', {}).get('dataset', "")
         )
 
-    logger.info(f"Using '{num_requesters_per_key}' requests per license (subsection).")
-
-    request_idxs = {name: itertools.cycle(range(num_requesters_per_key)) for name, _ in subsections}
-
-    def subsection_and_request(it: Config) -> t.Tuple[str, int]:
-        subsection = t.cast(str, it.get('parameters', {}).get('__subsection__', 'default'))
-        return subsection, next(request_idxs[subsection])
-
-    subsections_cycle = itertools.cycle(subsections)
-
-    def loop_through_subsections(it: Config) -> Partition:
-        """Assign a subsection to each config in a loop.
-
-        If the `parameters` section contains subsections (e.g. '[parameters.1]',
-        '[parameters.2]'), collect a repeating cycle of the subsection key-value
-        pairs. Otherwise, assign a default section to each config.
-
-        This is useful for specifying multiple API keys for your configuration.
-
-        For example:
-        ```
-          [parameters.alice]
-          api_key=KKKKK1
-          api_url=UUUUU1
-          [parameters.bob]
-          api_key=KKKKK2
-          api_url=UUUUU2
-          [parameters.eve]
-          api_key=KKKKK3
-          api_url=UUUUU3
-        ```
-        """
-        name, params = next(subsections_cycle)
-        return name, params, it
-
-    with beam.Pipeline(options=pipeline_options) as p:
-        (
-                p
-                | 'Create the initial config' >> beam.Create([config])
-                | 'Prepare partitions' >> beam.FlatMap(prepare_partitions)
-                | 'Skip existing downloads' >> beam.Filter(new_downloads_only, store=store)
-                | 'Cycle through subsections' >> beam.Map(loop_through_subsections)
-                | 'Assemble the data request' >> beam.Map(assemble_config, manifest=manifest)
-                | 'GroupBy request limits' >> beam.GroupBy(subsection_and_request)
-                | 'Fetch data' >> beam.ParDo(Fetcher(client_name, manifest, store))
-        )
+    return PipelineArgs(
+        known_args, pipeline_options, config, client_name, store, manifest, num_requesters_per_key
+    )


### PR DESCRIPTION
This change improves the modularity and testability of the downloader pipeline. Here, we extract out the partition preparation steps into its own composite PTransform. This provides a better location for the partitioning logic, and makes testing how we partition much better.

Next, we've decoupled running the pipeline from processing user arguments, and added unit tests to the user processing part. This ensures we can exercise logic about how to configure the pipeline without actually running it.