### PR TITLE
Fix minor bug: main session needs to be saved.

### DIFF
--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -211,8 +211,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
 
     # We use the save_main_session option because one or more DoFn's in this
     # workflow rely on global context (e.g., a module imported at module level).
-    pipeline_options = PipelineOptions(pipeline_args)
-    pipeline_options.view_as(SetupOptions).save_main_session = save_main_session
+    pipeline_options = PipelineOptions(pipeline_args + '--save_main_session True'.split())
 
     client_name = config['parameters']['client']
     store = None  # will default to using FileSystems()


### PR DESCRIPTION
Recently, I refactored the weather downloader pipeline to be more testable. Though I was setting the main session before and after that change (which is verified in tests), it somehow does not get propagated to Dataflow. As a result, the pipeline crashes with an NameError. 

This PR changes how we set `--save_main_session True`, which is more Dataflow + refactor friendly. 