### PR TITLE
Shrinking the size of the package release artifacts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+global-exclude *_test.py
+global-exclude *.nc
+global-exclude *.gb
+global-exclude *.md
+prune .github
+prune bin
+prune docs
+prune **test_data
+exclude tox.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,10 @@
 global-exclude *.nc
 global-exclude *.gb *.grib
 global-exclude *.bz2
-global-exclude *.md
-global-exclude *.cfg
-global-exclude *.json
 global-exclude *.yaml *.yml
 global-exclude *_test.py
 prune .github
 prune bin
 prune docs
-prune configs
 prune weather_*/test_data
 exclude tox.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,14 @@
-global-exclude **_test.py
 global-exclude *.nc
-global-exclude *.gb
+global-exclude *.gb *.grib
+global-exclude *.bz2
 global-exclude *.md
+global-exclude *.cfg
+global-exclude *.json
+global-exclude *.yaml *.yml
+global-exclude *_test.py
 prune .github
 prune bin
 prune docs
-prune **test_data
+prune configs
+prune weather_*/test_data
 exclude tox.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-global-exclude *_test.py
+global-exclude **_test.py
 global-exclude *.nc
 global-exclude *.gb
 global-exclude *.md


### PR DESCRIPTION
Fixes #121.

Before:
```
du -h dist/*
107M    dist/google-weather-tools-0.2.1.tar.gz
 88K    dist/google_weather_tools-0.2.1-py3-none-any.whl
```

After:
```
du -h dist/*
 44K    dist/google-weather-tools-0.2.2.dev2+g2b5c4da.d20220325.tar.gz
 88K    dist/google_weather_tools-0.2.2.dev2+g2b5c4da.d20220325-py3-none-any.whl
```