### PR TITLE
Flexible splits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ weather_sp_requirements = [
     "apache-beam[gcp]",
     "numpy>=1.20.3",
     "pygrib",
-    "netcdf4",
+    "xarray",
 ]
 
 test_requirements = [

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -78,7 +78,7 @@ On the other hand, to specify a specific pattern use
 --input-pattern 'gs://test-tmp/era5/2017/*/*.nc'
 ```
 
-## Output & Dimensions to split
+## Output & Split Dimensions
 
 The base output file names are specified using the `--output-template` or `--output-dir` flags. These flags are mutually
 exclusive, and one of them is required. \

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -11,9 +11,24 @@ Splits NetCDF and Grib files into several files by variable (_alpha_).
 ## Usage
 
 ```
-usage: weather-sp [-h] -i INPUT_PATTERN -output-dir OUTPUT_DIR [-d]
+usage: weather-sp [-h] -i INPUT_PATTERN (--output-template OUTPUT_TEMPLATE | --output-dir OUTPUT_DIR) [--formatting FORMATTING] [-d] [-f]
 
-Split weather data file into files by specified dimensions.
+Split weather data file into files by variable.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INPUT_PATTERN, --input-pattern INPUT_PATTERN
+                        Pattern for input weather data.
+  --output-template OUTPUT_TEMPLATE
+                        Template specifying path to output files using python-style formatting substitution of input directory names. For `input_pattern a/b/c/**` and file
+                        `a/b/c/file.grib`, a template with formatting `/somewhere/{1}-{0}.{level}_{shortName}.grib` will give `somewhere/c-file.level_shortName.grib`
+  --output-dir OUTPUT_DIR
+                        Output directory that will replace the common path of the input_pattern. For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, `outputdir /x/y/z` will create
+                        output files like `/x/y/z/c/file_variable.nc`
+  --formatting FORMATTING
+                        Used in combination with `output-dir`: specifies the how to split the data and format the output file. Example: `_{time}_{level}hPa`
+  -d, --dry-run         Test the input file matching and the output file scheme without splitting.
+  -f, --force           Force re-splitting of the pipeline. Turns of skipping of already split data.
 ```
 
 _Common options_:
@@ -89,13 +104,14 @@ For example, adding `{time}` in the output template or formatting will cause the
 How a file can be split depends on the file type.
 
 #### GRIB
-GRIB files can be split along any dimension that is available in the file's metadata. \
-Examples: 'typeOfLevel', 'level', 'step', 'shortName', 'gridType', 'time', 'forecastTime'
+GRIB files can be split along any dimensions that is available in the file's metadata. \
+Examples: 'typeOfLevel', 'level', 'step', 'shortName', 'gridType', 'time', 'forecastTime' \
+Any available dimensions can be combined when splitting.
 
 #### NetCDF
 NetCDF files are already in a hypercube format and can only be split by one of the dimensions and by data variable.
 Since splitting by latitude or longitude would lead to a large number of small files, this is not supported,
-and it is recommended to use the weather-mv tool instead. \
+and it is recommended to use the `weather-mv` tool instead. \
 Supported splits for NetCDF files are thus 'variable', 'time', 'level'.
 
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -12,23 +12,6 @@ Splits NetCDF and Grib files into several files by variable (_alpha_).
 
 ```
 usage: weather-sp [-h] -i INPUT_PATTERN (--output-template OUTPUT_TEMPLATE | --output-dir OUTPUT_DIR) [--formatting FORMATTING] [-d] [-f]
-
-Split weather data file into files by variable.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -i INPUT_PATTERN, --input-pattern INPUT_PATTERN
-                        Pattern for input weather data.
-  --output-template OUTPUT_TEMPLATE
-                        Template specifying path to output files using python-style formatting substitution of input directory names. For `input_pattern a/b/c/**` and file
-                        `a/b/c/file.grib`, a template with formatting `/somewhere/{1}-{0}.{level}_{shortName}.grib` will give `somewhere/c-file.level_shortName.grib`
-  --output-dir OUTPUT_DIR
-                        Output directory that will replace the common path of the input_pattern. For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, `outputdir /x/y/z` will create
-                        output files like `/x/y/z/c/file_variable.nc`
-  --formatting FORMATTING
-                        Used in combination with `output-dir`: specifies the how to split the data and format the output file. Example: `_{time}_{level}hPa`
-  -d, --dry-run         Test the input file matching and the output file scheme without splitting.
-  -f, --force           Force re-splitting of the pipeline. Turns of skipping of already split data.
 ```
 
 _Common options_:
@@ -50,6 +33,7 @@ _Usage examples_:
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --output-dir 'gs://test-tmp/era5/splits'
+           --formatting '.{typeOfLevel}'
 ```
 
 Preview splits with a dry run:
@@ -57,6 +41,7 @@ Preview splits with a dry run:
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --output-dir 'gs://test-tmp/era5/splits' \
+           --formatting '.{typeOfLevel}'
            --dry-run
 ```
 
@@ -65,6 +50,7 @@ Using DataflowRunner
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2015/**' \
            --output-dir 'gs://test-tmp/era5/splits'
+           --formatting '.{typeOfLevel}'
            --runner DataflowRunner \
            --project $PROJECT \
            --temp_location gs://$BUCKET/tmp  \
@@ -122,21 +108,19 @@ Based on the output directory path, the directory structure of the input pattern
 To create the directory structure, the common path of the input pattern is removed from the input file path and replaced
 with the output path. \
 The formatting specified by the `--formatting` flag is added between file name and ending and is
-used to determine along which dimensions to split.\
-If `--formatting` is not specified, file type-specific defaults are used:
-* GRIB: '_{typeOfLevel}_{shortName}'
-* NetCFD: '_{variable}'
+used to determine along which dimensions to split.
 
 Example:
 
 ```bash
 --input-pattern 'gs://test-input/era5/2020/**' \
 --output-dir 'gs://test-output/splits'
+--formatting '.{variable}'
 ```
 
 For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
-`gs://test-output/splits/2020/02/01_{variable}.nc` and if the temperature is a variable in that data, the output file
-for that split will be `gs://test-output/splits/2020/02/01_t.nc`.
+`gs://test-output/splits/2020/02/01.{variable}.nc` and if the temperature is a variable in that data, the output file
+for that split will be `gs://test-output/splits/2020/02/01.t.nc`.
 
 Example:
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -11,18 +11,20 @@ Splits NetCDF and Grib files into several files by variable (_alpha_).
 ## Usage
 
 ```
-usage: weather-sp [-h] -i INPUT_PATTERN -o OUTPUT_DIR [-d]
+usage: weather-sp [-h] -i INPUT_PATTERN -output-dir OUTPUT_DIR [-d]
 
-Split weather data file into files by variable.
+Split weather data file into files by specified dimensions.
 ```
 
 _Common options_:
 
 * `-i, --input-pattern`: Pattern for input weather data.
-* `--output-template`: Path to template using Python formatting, see [Output section](#output) below. Mutually exclusive
+* `--output-template`: Template of output file path using Python formatting, see [Output section](#output) below. Mutually exclusive
   with `--output-dir`.
 * `--output-dir`: Path to base folder for output files, see [Output section](#output) below. Mutually exclusive
   with `--output-template`
+* `--formatting`: Used only with `--output-dir` to specify splitting and output format
+   using Python formatting, see [Output section](#output) below.
 * `-f, --force`: Force re-splitting of the pipeline. Turns of skipping of already split data.
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
 
@@ -75,17 +77,39 @@ On the other hand, to specify a specific pattern use
 --input-pattern 'gs://test-tmp/era5/2017/*/*.nc'
 ```
 
-## Output
+## Output & Dimensions to split
 
 The base output file names are specified using the `--output-template` or `--output-dir` flags. These flags are mutually
-exclusive, and one of them is required.
+exclusive, and one of them is required. \
+The output formatting also specifies which dimensions to split by using Python formatting.
+For example, adding `{time}` in the output template or formatting will cause the file to be split along the time dimension.
+
+### Available dimensions to split
+
+How a file can be split depends on the file type.
+
+#### GRIB
+GRIB files can be split along any dimension that is available in the file's metadata. \
+Examples: 'typeOfLevel', 'level', 'step', 'shortName', 'gridType', 'time', 'forecastTime'
+
+#### NetCDF
+NetCDF files are already in a hypercube format and can only be split by one of the dimensions and by data variable.
+Since splitting by latitude or longitude would lead to a large number of small files, this is not supported,
+and it is recommended to use the weather-mv tool instead. \
+Supported splits for NetCDF files are thus 'variable', 'time', 'level'.
+
 
 ### Output directory
 
 Based on the output directory path, the directory structure of the input pattern is replicated.
 
 To create the directory structure, the common path of the input pattern is removed from the input file path and replaced
-with the output path. A '_' is added to separate the split level / variable.
+with the output path. \
+The formatting specified by the `--formatting` flag is added between file name and ending and is
+used to determine along which dimensions to split.\
+If `--formatting` is not specified, file type-specific defaults are used:
+* GRIB: '_{typeOfLevel}_{shortName}'
+* NetCFD: '_{variable}'
 
 Example:
 
@@ -95,26 +119,38 @@ Example:
 ```
 
 For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
-`gs://test-output/splits/2020/02/01.{shortname}.nc` and if the temperature is a variable in that data, the output file
-for that split will be `gs://test-output/splits/2020/02/01.t.nc`
+`gs://test-output/splits/2020/02/01_{variable}.nc` and if the temperature is a variable in that data, the output file
+for that split will be `gs://test-output/splits/2020/02/01_t.nc`.
+
+Example:
+
+```bash
+--input-pattern 'gs://test-input/era5/2020/**' \
+--output-dir 'gs://test-output/splits'
+--formatting '_{date}:{time}_{level}hPa'
+```
+For a file `gs://test-input/era5/2020/02/01.grib` the output file pattern is
+`gs://test-output/splits/2020/02/01_{date}:{time}_{level}hPa.grib` and for date = 20200101, time = 1200, level = 400,
+ the output file for that split will be `gs://test-output/splits/2020/02/01_20200101:1200_400hPa.grib`.
+
 
 ### Output template with Python-style formatting
 
 Using Python-style substitution (e.g. `{1}`) allows for more flexibility when creating the output files. The
 substitutions are based on the directory structure of the input file, where each `{<x>}` stands for one directory name,
 counting backwards from the end, i.e. the file name is `{0}`, the immediate directory in which it is located is `{1}`,
-and so on. In addition, you may supply `{shortname}` or `{levelType}` in the output template. These will be filled by values
-found in each file (NetCDF files typically only have one type of level, so this variable is not needed).
+and so on. In addition, you need to supply the split dimensions in the output template. These will be filled by values
+found in each file.
 
 Example:
 
 ```bash
 --input-pattern 'gs://test-input/era5/2020/**' \
---output-template 'gs://test-output/splits/{2}.{0}.{1}T00.{shortname}.nc'
+--output-template 'gs://test-output/splits/{2}.{0}.{1}T00.{variable}.nc'
 ```
 
 For a file `gs://test-input/era5/2020/02/01.nc` the output file pattern is
-`gs://test-output/splits/2020.01.02T00.{shortname}.nc` and if the temperature is a variable in that data, the output
+`gs://test-output/splits/2020.01.02T00.{variable}.nc` and if the temperature is a variable in that data, the output
 file for that split will be `gs://test-output/splits/2020.01.02T00.t.nc`
 
 ## Dry run

--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.1',
+    version='0.3.0',
     url='https://weather-tools.readthedocs.io/en/latest/weather_sp/',
     description='A tool to split weather data files into per-variable files.',
     install_requires=base_requirements,

--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -18,7 +18,7 @@ base_requirements = [
     "apache-beam[gcp]",
     "pygrib",
     "numpy>=1.20.3",
-    "netcdf4",
+    "xarray",
 ]
 
 setup(

--- a/weather_sp/splitter_pipeline/file_name_utils.py
+++ b/weather_sp/splitter_pipeline/file_name_utils.py
@@ -24,7 +24,9 @@ NETCDF_FILE_ENDINGS = ('.nc', '.cd')
 
 class OutFileInfo(t.NamedTuple):
     file_name_template: str
-    ending: str
+    formatting: str = ''
+    ending: str = ''
+    template_folders: t.List[str] = []
     output_dir: bool = False
 
     def __str__(self):
@@ -34,7 +36,8 @@ class OutFileInfo(t.NamedTuple):
 def get_output_file_base_name(filename: str,
                               input_base_dir: str = '',
                               out_pattern: t.Optional[str] = None,
-                              out_dir: t.Optional[str] = None) -> OutFileInfo:
+                              out_dir: t.Optional[str] = None,
+                              formatting: str = '') -> OutFileInfo:
     """Construct the base output file name by applying the out_pattern to the filename.
 
     Example:
@@ -47,6 +50,8 @@ def get_output_file_base_name(filename: str,
         filename: input file to be split
         out_pattern: pattern to apply when creating output file
         out_dir: directory to replace input base directory
+        formatting: output formatting of split fields. Required when using out_dir,
+             ignored when using out_pattern.
         input_base_dir: used if out_pattern does not contain any '{}' substitutions.
             The output file is then created by replacing this part of the input name
             with the output pattern.
@@ -59,8 +64,10 @@ def get_output_file_base_name(filename: str,
 
     if out_dir:
         return OutFileInfo(
-            f'{filename.replace(input_base_dir, out_dir)}.{{levelType}}{{shortname}}{ending}',
+            f'{filename.replace(input_base_dir, out_dir)}',
+            formatting,
             ending,
+            [],
             output_dir=True
         )
 
@@ -70,6 +77,8 @@ def get_output_file_base_name(filename: str,
         while path:
             path, tail = os.path.split(path)
             in_sections.append(tail)
-        return OutFileInfo(out_pattern.format(*in_sections, shortname="{shortname}", levelType="{levelType}"), ending)
+        # setting formatting and ending to empty strings since they are
+        # part of the specified pattern.
+        return OutFileInfo(out_pattern, '', '', in_sections)
 
     raise ValueError('no output specified.')

--- a/weather_sp/splitter_pipeline/file_name_utils.py
+++ b/weather_sp/splitter_pipeline/file_name_utils.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass, field
 import logging
 import os
+import string
 import typing as t
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,11 @@ class OutFileInfo:
     def unformatted_output_path(self):
         """Construct output file name with formatting marks."""
         return self.file_name_template + self.formatting + self.ending
+
+    def split_dims(self) -> t.List[str]:
+        all_format = list(filter(None, [field[1] for field in string.Formatter().parse(
+            self.unformatted_output_path())]))
+        return [key for key in all_format if not key.isdigit()]
 
     def set_formatting_if_needed(self, formatting: str):
         """If formatting string is required but not present, set formatting.

--- a/weather_sp/splitter_pipeline/file_name_utils.py
+++ b/weather_sp/splitter_pipeline/file_name_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass, field
 import logging
 import os
 import typing as t
@@ -22,25 +23,29 @@ GRIB_FILE_ENDINGS = ('.grib', '.grb', '.grb2', '.grib2', '.gb')
 NETCDF_FILE_ENDINGS = ('.nc', '.cd')
 
 
+@dataclass
 class OutFileInfo:
-    """Holds data required to construct an output file name."""
+    """Holds data required to construct an output file name.
 
-    def __init__(self, file_name_template: str,
-                 formatting: str = '',
-                 ending: str = '',
-                 template_folders: t.List[str] = [],
-                 requires_formatting: bool = False):
-        self.file_name_template = file_name_template
-        self.formatting = formatting
-        self.ending = ending
-        self.template_folders = template_folders
-        self.requires_formatting = requires_formatting
+    Attributes:
+        file_name_template: base output path, may contain python-style formatting
+                            marks. This can be a base directory or a full name.
+        formatting: added after file_name_template to add formatting. Only used
+                    when using --output-dir.
+        ending: file ending.
+        template_folders:
+    """
+    file_name_template: str
+    formatting: str = ''
+    ending: str = ''
+    template_folders: t.List[str] = field(default_factory=lambda: [])
+    requires_formatting: bool = False
 
-    def __str__(self):
-        return self.get_unformatted_output_name()
+    def __repr__(self):
+        return self.unformatted_output_path()
 
-    def get_unformatted_output_name(self):
-        """Construct base output file name with formatting marks."""
+    def unformatted_output_path(self):
+        """Construct output file name with formatting marks."""
         return self.file_name_template + self.formatting + self.ending
 
     def set_formatting_if_needed(self, formatting: str):
@@ -51,9 +56,9 @@ class OutFileInfo:
         if self.requires_formatting and not self.formatting:
             self.formatting = formatting
 
-    def get_formatted_output_file_path(self, splits: t.Dict[str, str]) -> str:
+    def formatted_output_path(self, splits: t.Dict[str, str]) -> str:
         """Construct output file name with formatting applied"""
-        return self.get_unformatted_output_name().format(*self.template_folders, **splits)
+        return self.unformatted_output_path().format(*self.template_folders, **splits)
 
 
 def get_output_file_info(filename: str,

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -14,64 +14,97 @@
 
 import unittest
 
-from .file_name_utils import get_output_file_base_name
+from .file_name_utils import get_output_file_info
 
 
 class FileNameUtilsTest(unittest.TestCase):
 
-    def test_get_output_file_base_name_format(self):
-        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
-                                             out_dir=None,
-                                             input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
-        self.assertEqual(out_info.template_folders, ['21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
+    def test_get_output_file_info_format(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                        out_dir=None,
+                                        input_base_dir='ignored')
+        self.assertEqual(out_info.file_name_template,
+                         'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
+        self.assertEqual(out_info.template_folders, [
+                         '21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
         self.assertEqual(out_info.ending, '')
         self.assertEqual(out_info.formatting, '')
-        self.assertEqual(out_info.output_dir, False)
+        self.assertEqual(out_info.requires_formatting, False)
 
-    def test_get_output_file_base_name_replace(self):
-        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_pattern=None,
-                                             out_dir='gs://my_bucket/splits/',
-                                             input_base_dir='gs://my_bucket/data_to_split/')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21')
+    def test_get_output_file_info_replace(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_pattern=None,
+                                        out_dir='gs://my_bucket/splits/',
+                                        input_base_dir='gs://my_bucket/data_to_split/')
+        self.assertEqual(out_info.file_name_template,
+                         'gs://my_bucket/splits/2020/01/21')
         self.assertEqual(out_info.ending, '.nc')
         self.assertEqual(out_info.formatting, '')
-        self.assertEqual(out_info.output_dir, True)
+        self.assertEqual(out_info.requires_formatting, True)
 
-    def test_get_output_file_base_name_format_no_fileending(self):
-        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21',
-                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
-                                             out_dir=None,
-                                             input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.')
+    def test_get_output_file_info_format_no_fileending(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21',
+                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                        out_dir=None,
+                                        input_base_dir='ignored')
+        self.assertEqual(out_info.file_name_template,
+                         'gs://my_bucket/splits/{2}-{1}-{0}_old_data.')
         self.assertEqual(out_info.ending, '')
 
-    def test_get_output_file_base_name_format_filecontainsdots(self):
-        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
-                                             out_dir='gs://my_bucket/splits/',
-                                             input_base_dir='gs://my_bucket/data_to_split/')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21.T00z.stuff')
+    def test_get_output_file_info_format_filecontainsdots(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
+                                        out_dir='gs://my_bucket/splits/',
+                                        input_base_dir='gs://my_bucket/data_to_split/')
+        self.assertEqual(out_info.file_name_template,
+                         'gs://my_bucket/splits/2020/01/21.T00z.stuff')
         self.assertEqual(out_info.ending, '')
 
-    def test_output_dir_formatting(self):
-        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_dir='gs://my_bucket/splits/',
-                                             input_base_dir='gs://my_bucket/data_to_split/',
-                                             formatting='_{time}_{level}hPa')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21')
+    def test_requires_formatting_formatting(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_dir='gs://my_bucket/splits/',
+                                        input_base_dir='gs://my_bucket/data_to_split/',
+                                        formatting='_{time}_{level}hPa')
+        self.assertEqual(out_info.file_name_template,
+                         'gs://my_bucket/splits/2020/01/21')
         self.assertEqual(out_info.formatting, '_{time}_{level}hPa')
         self.assertEqual(out_info.ending, '.nc')
 
     def test_output_pattern_ignores_formatting(self):
-        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
-                                             out_dir=None,
-                                             input_base_dir='ignored',
-                                             formatting='_{time}_{level}hPa')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
-        self.assertEqual(out_info.template_folders, ['21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                        out_dir=None,
+                                        input_base_dir='ignored',
+                                        formatting='_{time}_{level}hPa')
+        self.assertEqual(out_info.file_name_template,
+                         'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
+        self.assertEqual(out_info.template_folders, [
+                         '21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
         self.assertEqual(out_info.ending, '')
         self.assertEqual(out_info.formatting, '')
-        self.assertEqual(out_info.output_dir, False)
+        self.assertEqual(out_info.requires_formatting, False)
+
+    def test_set_formatting_if_needed__sets(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_dir='gs://my_bucket/splits/',
+                                        input_base_dir='gs://my_bucket/data_to_split/')
+        self.assertEqual(out_info.formatting, '')
+        out_info.set_formatting_if_needed('_{format}')
+        self.assertEqual(out_info.formatting, '_{format}')
+
+    def test_set_formatting_if_needed__not_needed(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_pattern='gs://my_bucket/splits/{0}.{variable}',
+                                        input_base_dir='gs://my_bucket/data_to_split/')
+        self.assertEqual(out_info.formatting, '')
+        out_info.set_formatting_if_needed('_{format}')
+        self.assertEqual(out_info.formatting, '')
+
+    def test_set_formatting_if_needed__does_not_overwrite(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_dir='gs://my_bucket/splits/',
+                                        input_base_dir='gs://my_bucket/data_to_split/',
+                                        formatting='_{orig_format}')
+        self.assertEqual(out_info.formatting, '_{orig_format}')
+        out_info.set_formatting_if_needed('_{format}')
+        self.assertEqual(out_info.formatting, '_{orig_format}')

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -20,55 +20,55 @@ from .file_name_utils import get_output_file_info, OutFileInfo
 class FileNameUtilsTest(unittest.TestCase):
 
     def test_get_output_file_info_pattern(self):
-        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
-                                        out_dir='',
-                                        input_base_dir='ignored')
+        actual = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                      out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                      out_dir='',
+                                      input_base_dir='ignored')
         expected = OutFileInfo(
             file_name_template='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
             template_folders=['21', '01', '2020',
                               'data_to_split', 'my_bucket', 'gs:'],
             ending='',
             formatting='')
-        self.assertEqual(out_info, expected)
+        self.assertEqual(actual, expected)
 
     def test_get_output_file_info_dir(self):
-        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                        out_pattern='',
-                                        out_dir='gs://my_bucket/splits/',
-                                        input_base_dir='gs://my_bucket/data_to_split/',
-                                        formatting='_{foo}')
+        actual = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                      out_pattern='',
+                                      out_dir='gs://my_bucket/splits/',
+                                      input_base_dir='gs://my_bucket/data_to_split/',
+                                      formatting='_{foo}')
         expected = OutFileInfo(
             file_name_template='gs://my_bucket/splits/2020/01/21',
             template_folders=[],
             ending='.nc',
             formatting='_{foo}')
-        self.assertEqual(out_info, expected)
+        self.assertEqual(actual, expected)
 
     def test_get_output_file_info_no_fileending(self):
-        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21',
-                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
-                                        out_dir='',
-                                        input_base_dir='ignored')
+        actual = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21',
+                                      out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                      out_dir='',
+                                      input_base_dir='ignored')
         expected = OutFileInfo(
             file_name_template='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
             template_folders=['21', '01', '2020',
                               'data_to_split', 'my_bucket', 'gs:'],
             ending='',
             formatting='')
-        self.assertEqual(out_info, expected)
+        self.assertEqual(actual, expected)
 
     def test_get_output_file_info_filecontainsdots(self):
-        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
-                                        out_dir='gs://my_bucket/splits/',
-                                        input_base_dir='gs://my_bucket/data_to_split/',
-                                        formatting='.{foo}')
+        actual = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
+                                      out_dir='gs://my_bucket/splits/',
+                                      input_base_dir='gs://my_bucket/data_to_split/',
+                                      formatting='.{foo}')
         expected = OutFileInfo(
             file_name_template='gs://my_bucket/splits/2020/01/21.T00z.stuff',
             template_folders=[],
             ending='',
             formatting='.{foo}')
-        self.assertEqual(out_info, expected)
+        self.assertEqual(actual, expected)
 
     def test_get_output_file_info_dir_no_formatting(self):
         with self.assertRaises(ValueError):
@@ -78,22 +78,22 @@ class FileNameUtilsTest(unittest.TestCase):
                                  input_base_dir='gs://my_bucket/data_to_split/')
 
     def test_output_pattern_ignores_formatting(self):
-        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
-                                        out_dir=None,
-                                        input_base_dir='ignored',
-                                        formatting='_{time}_{level}hPa')
+        actual = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                      out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                      out_dir=None,
+                                      input_base_dir='ignored',
+                                      formatting='_{time}_{level}hPa')
         expected = OutFileInfo(
             file_name_template='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
             template_folders=['21', '01', '2020',
                               'data_to_split', 'my_bucket', 'gs:'],
             ending='',
             formatting='')
-        self.assertEqual(out_info, expected)
+        self.assertEqual(actual, expected)
 
     def test_split_dims(self):
-        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
-                                        out_dir=None,
-                                        input_base_dir='ignored')
-        self.assertEqual(out_info.split_dims(), ['variable'])
+        actual = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                      out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                      out_dir=None,
+                                      input_base_dir='ignored')
+        self.assertEqual(actual.split_dims(), ['variable'])

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -21,51 +21,57 @@ class FileNameUtilsTest(unittest.TestCase):
 
     def test_get_output_file_base_name_format(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
                                              out_dir=None,
                                              input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020-01-21_old_data.')
-        self.assertEqual(out_info.ending, '.nc')
+        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
+        self.assertEqual(out_info.template_folders, ['21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
+        self.assertEqual(out_info.ending, '')
+        self.assertEqual(out_info.formatting, '')
+        self.assertEqual(out_info.output_dir, False)
 
     def test_get_output_file_base_name_replace(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
                                              out_pattern=None,
                                              out_dir='gs://my_bucket/splits/',
                                              input_base_dir='gs://my_bucket/data_to_split/')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21.{levelType}{shortname}.nc')
+        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21')
         self.assertEqual(out_info.ending, '.nc')
+        self.assertEqual(out_info.formatting, '')
+        self.assertEqual(out_info.output_dir, True)
 
     def test_get_output_file_base_name_format_no_fileending(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21',
                                              out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
                                              out_dir=None,
                                              input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020-01-21_old_data.')
+        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.')
         self.assertEqual(out_info.ending, '')
 
     def test_get_output_file_base_name_format_filecontainsdots(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
-                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
-                                             out_dir=None,
-                                             input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020-01-21.T00z.stuff_old_data.')
+                                             out_dir='gs://my_bucket/splits/',
+                                             input_base_dir='gs://my_bucket/data_to_split/')
+        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21.T00z.stuff')
         self.assertEqual(out_info.ending, '')
 
-    def test_accepts_shortname(self):
+    def test_output_dir_formatting(self):
         out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{shortname}.nc',
-                                             out_dir=None,
-                                             input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020-01-21_old_data.{shortname}.nc')
+                                             out_dir='gs://my_bucket/splits/',
+                                             input_base_dir='gs://my_bucket/data_to_split/',
+                                             formatting='_{time}_{level}hPa')
+        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/2020/01/21')
+        self.assertEqual(out_info.formatting, '_{time}_{level}hPa')
         self.assertEqual(out_info.ending, '.nc')
 
-    def test_accepts_shortname_and_level(self):
-        out_info = get_output_file_base_name(
-            filename='gs://my_bucket/data_to_split/2020/01/21.nc',
-            out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{levelType}_{shortname}.nc',
-            out_dir=None,
-            input_base_dir='ignored'
-        )
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/2020-01-21_old_data.{levelType}_{shortname}.nc')
-        self.assertEqual(out_info.ending, '.nc')
+    def test_output_pattern_ignores_formatting(self):
+        out_info = get_output_file_base_name(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                             out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                             out_dir=None,
+                                             input_base_dir='ignored',
+                                             formatting='_{time}_{level}hPa')
+        self.assertEqual(out_info.file_name_template, 'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
+        self.assertEqual(out_info.template_folders, ['21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
+        self.assertEqual(out_info.ending, '')
+        self.assertEqual(out_info.formatting, '')
+        self.assertEqual(out_info.output_dir, False)

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -108,3 +108,10 @@ class FileNameUtilsTest(unittest.TestCase):
         self.assertEqual(out_info.formatting, '_{orig_format}')
         out_info.set_formatting_if_needed('_{format}')
         self.assertEqual(out_info.formatting, '_{orig_format}')
+
+    def test_split_dims(self):
+        out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
+                                        out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+                                        out_dir=None,
+                                        input_base_dir='ignored')
+        self.assertEqual(out_info.split_dims(), ['variable'])

--- a/weather_sp/splitter_pipeline/file_name_utils_test.py
+++ b/weather_sp/splitter_pipeline/file_name_utils_test.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from .file_name_utils import get_output_file_info
+from .file_name_utils import get_output_file_info, OutFileInfo
 
 
 class FileNameUtilsTest(unittest.TestCase):
@@ -24,51 +24,66 @@ class FileNameUtilsTest(unittest.TestCase):
                                         out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
                                         out_dir=None,
                                         input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
-        self.assertEqual(out_info.template_folders, [
-                         '21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
-        self.assertEqual(out_info.ending, '')
-        self.assertEqual(out_info.formatting, '')
-        self.assertEqual(out_info.requires_formatting, False)
+        expected = OutFileInfo(
+            file_name_template='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+            template_folders=['21', '01', '2020',
+                              'data_to_split', 'my_bucket', 'gs:'],
+            ending='',
+            formatting='',
+            requires_formatting=False)
+        self.assertEqual(out_info, expected)
 
     def test_get_output_file_info_replace(self):
         out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
                                         out_pattern=None,
                                         out_dir='gs://my_bucket/splits/',
                                         input_base_dir='gs://my_bucket/data_to_split/')
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/2020/01/21')
-        self.assertEqual(out_info.ending, '.nc')
-        self.assertEqual(out_info.formatting, '')
-        self.assertEqual(out_info.requires_formatting, True)
+        expected = OutFileInfo(
+            file_name_template='gs://my_bucket/splits/2020/01/21',
+            template_folders=[],
+            ending='.nc',
+            formatting='',
+            requires_formatting=True)
+        self.assertEqual(out_info, expected)
 
     def test_get_output_file_info_format_no_fileending(self):
         out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21',
                                         out_pattern='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
                                         out_dir=None,
                                         input_base_dir='ignored')
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/{2}-{1}-{0}_old_data.')
-        self.assertEqual(out_info.ending, '')
+        expected = OutFileInfo(
+            file_name_template='gs://my_bucket/splits/{2}-{1}-{0}_old_data.',
+            template_folders=['21', '01', '2020',
+                              'data_to_split', 'my_bucket', 'gs:'],
+            ending='',
+            formatting='',
+            requires_formatting=False)
+        self.assertEqual(out_info, expected)
 
     def test_get_output_file_info_format_filecontainsdots(self):
         out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.T00z.stuff',
                                         out_dir='gs://my_bucket/splits/',
                                         input_base_dir='gs://my_bucket/data_to_split/')
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/2020/01/21.T00z.stuff')
-        self.assertEqual(out_info.ending, '')
+        expected = OutFileInfo(
+            file_name_template='gs://my_bucket/splits/2020/01/21.T00z.stuff',
+            template_folders=[],
+            ending='',
+            formatting='',
+            requires_formatting=True)
+        self.assertEqual(out_info, expected)
 
     def test_requires_formatting_formatting(self):
         out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
                                         out_dir='gs://my_bucket/splits/',
                                         input_base_dir='gs://my_bucket/data_to_split/',
                                         formatting='_{time}_{level}hPa')
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/2020/01/21')
-        self.assertEqual(out_info.formatting, '_{time}_{level}hPa')
-        self.assertEqual(out_info.ending, '.nc')
+        expected = OutFileInfo(
+            file_name_template='gs://my_bucket/splits/2020/01/21',
+            template_folders=[],
+            ending='.nc',
+            formatting='_{time}_{level}hPa',
+            requires_formatting=True)
+        self.assertEqual(out_info, expected)
 
     def test_output_pattern_ignores_formatting(self):
         out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',
@@ -76,13 +91,14 @@ class FileNameUtilsTest(unittest.TestCase):
                                         out_dir=None,
                                         input_base_dir='ignored',
                                         formatting='_{time}_{level}hPa')
-        self.assertEqual(out_info.file_name_template,
-                         'gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}')
-        self.assertEqual(out_info.template_folders, [
-                         '21', '01', '2020', 'data_to_split', 'my_bucket', 'gs:'])
-        self.assertEqual(out_info.ending, '')
-        self.assertEqual(out_info.formatting, '')
-        self.assertEqual(out_info.requires_formatting, False)
+        expected = OutFileInfo(
+            file_name_template='gs://my_bucket/splits/{2}-{1}-{0}_old_data.{variable}',
+            template_folders=['21', '01', '2020',
+                              'data_to_split', 'my_bucket', 'gs:'],
+            ending='',
+            formatting='',
+            requires_formatting=False)
+        self.assertEqual(out_info, expected)
 
     def test_set_formatting_if_needed__sets(self):
         out_info = get_output_file_info(filename='gs://my_bucket/data_to_split/2020/01/21.nc',

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -72,7 +72,8 @@ class FileSplitter(abc.ABC):
             return False
 
         for match in FileSystems().match([
-            self.output_info.formatted_output_path({var: '*' for var in self.output_info.split_dims()}),
+            self.output_info.formatted_output_path(
+                {var: '*' for var in self.output_info.split_dims()}),
         ]):
             if len(match.metadata_list) > 0:
                 return True
@@ -85,7 +86,6 @@ class GribSplitter(FileSplitter):
                  force_split: bool = False, logging_level: int = logging.INFO):
         super().__init__(input_path, output_info,
                          force_split, logging_level)
-        self.output_info.set_formatting_if_needed('_{typeOfLevel}_{shortName}')
 
     def split_data(self) -> None:
         if not self.output_info.split_dims():
@@ -130,7 +130,6 @@ class NetCdfSplitter(FileSplitter):
                  force_split: bool = False, logging_level: int = logging.INFO):
         super().__init__(input_path, output_info,
                          force_split, logging_level)
-        self.output_info.set_formatting_if_needed('_{variable}')
 
     def split_data(self) -> None:
         if not self.output_info.split_dims():
@@ -191,7 +190,6 @@ class DrySplitter(FileSplitter):
                  force_split: bool = False, logging_level: int = logging.INFO):
         super().__init__(input_path, output_info,
                          force_split, logging_level)
-        self.output_info.set_formatting_if_needed('_{default_for_filetype}')
 
     def split_data(self) -> None:
         if not self.output_info.split_dims():

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -37,28 +37,40 @@ class GetSplitterTest(unittest.TestCase):
     def test_get_splitter_grib(self):
         splitter = get_splitter(f'{self._data_dir}/era5_sample.grib',
                                 OutFileInfo(
-                                    file_name_template='some_out_{split}', ending='.grib'),
+                                    file_name_template='some_out_{split}',
+                                    ending='.grib',
+                                    formatting='',
+                                    template_folders=[]),
                                 dry_run=False)
         self.assertIsInstance(splitter, GribSplitter)
 
     def test_get_splitter_nc(self):
         splitter = get_splitter(f'{self._data_dir}/era5_sample.nc',
                                 OutFileInfo(
-                                    file_name_template='some_out_{split}', ending='.nc'),
+                                    file_name_template='some_out_{split}',
+                                    ending='.nc',
+                                    formatting='',
+                                    template_folders=[]),
                                 dry_run=False)
         self.assertIsInstance(splitter, NetCdfSplitter)
 
     def test_get_splitter_undetermined_grib(self):
         splitter = get_splitter(f'{self._data_dir}/era5_sample_grib',
                                 OutFileInfo(
-                                    file_name_template='some_out_{split}', ending=''),
+                                    file_name_template='some_out_{split}',
+                                    ending='',
+                                    formatting='',
+                                    template_folders=[]),
                                 dry_run=False)
         self.assertIsInstance(splitter, GribSplitter)
 
     def test_get_splitter_dryrun(self):
         splitter = get_splitter('some/file/path/data.grib',
                                 OutFileInfo(
-                                    file_name_template='some_out_{split}', ending='.grib'),
+                                    file_name_template='some_out_{split}',
+                                    ending='.grib',
+                                    formatting='',
+                                    template_folders=[]),
                                 dry_run=True)
         self.assertIsInstance(splitter, DrySplitter)
 
@@ -77,7 +89,10 @@ class GribSplitterTest(unittest.TestCase):
         splitter = GribSplitter(
             'path/to/input',
             OutFileInfo(
-                file_name_template='path/output/file.{typeOfLevel}_{shortName}', ending='.grib')
+                file_name_template='path/output/file.{typeOfLevel}_{shortName}',
+                ending='.grib',
+                formatting='',
+                template_folders=[])
         )
         out = splitter.output_info.formatted_output_path(
             {'typeOfLevel': 'surface', 'shortName': 'cc'})
@@ -89,7 +104,10 @@ class GribSplitterTest(unittest.TestCase):
         splitter = GribSplitter(
             input_path,
             OutFileInfo(
-                output_base, formatting='_{typeOfLevel}_{shortName}', ending='.grib')
+                output_base,
+                formatting='_{typeOfLevel}_{shortName}',
+                ending='.grib',
+                template_folders=[])
         )
         splitter.split_data()
         self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
@@ -119,7 +137,9 @@ class GribSplitterTest(unittest.TestCase):
         splitter = GribSplitter(
             input_path,
             OutFileInfo(f'{self._data_dir}/split_files/era5_sample',
-                        formatting='_{typeOfLevel}_{shortName}', ending='.grib')
+                        formatting='_{typeOfLevel}_{shortName}',
+                        ending='.grib',
+                        template_folders=[])
         )
         self.assertFalse(splitter.should_skip())
         splitter.split_data()
@@ -132,7 +152,10 @@ class GribSplitterTest(unittest.TestCase):
         splitter = GribSplitter(
             input_path,
             OutFileInfo(
-                output_base, formatting='_{levelType}_{shortName}', ending='.grib'),
+                output_base,
+                formatting='_{levelType}_{shortName}',
+                ending='.grib',
+                template_folders=[]),
             force_split=True
         )
         self.assertFalse(splitter.should_skip())
@@ -153,15 +176,24 @@ class NetCdfSplitterTest(unittest.TestCase):
 
     def test_get_output_file_path(self):
         splitter = NetCdfSplitter(
-            'path/to/input', OutFileInfo('path/output/file_{variable}', '.nc'))
+            'path/to/input',
+            OutFileInfo('path/output/file_{variable}',
+                        ending='.nc',
+                        formatting='',
+                        template_folders=[]))
         out = splitter.output_info.formatted_output_path({'variable': 'cc'})
         self.assertEqual(out, 'path/output/file_cc.nc')
 
     def test_split_data(self):
         input_path = f'{self._data_dir}/era5_sample.nc'
         output_base = f'{self._data_dir}/split_files/era5_sample'
-        splitter = NetCdfSplitter(input_path,
-                                  OutFileInfo(output_base, formatting='_{time}_{variable}', ending='.nc'))
+        splitter = NetCdfSplitter(
+            input_path,
+            OutFileInfo(output_base,
+                        formatting='_{time}_{variable}',
+                        ending='.nc',
+                        template_folders=[]))
+
         splitter.split_data()
         self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
         input_data = xr.open_dataset(input_path, engine='netcdf4')
@@ -176,7 +208,10 @@ class NetCdfSplitterTest(unittest.TestCase):
         input_path = f'{self._data_dir}/era5_sample.nc'
         output_base = f'{self._data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
-                                  OutFileInfo(output_base, formatting='_{level}', ending='.nc'))
+                                  OutFileInfo(output_base,
+                                              formatting='_{level}',
+                                              ending='.nc',
+                                              template_folders=[]))
         with self.assertRaises(ValueError):
             splitter.split_data()
 
@@ -184,7 +219,10 @@ class NetCdfSplitterTest(unittest.TestCase):
         input_path = f'{self._data_dir}/era5_sample.nc'
         output_base = f'{self._data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
-                                  OutFileInfo(output_base, formatting='_{shortName}', ending='.nc'))
+                                  OutFileInfo(output_base,
+                                              formatting='_{shortName}',
+                                              ending='.nc',
+                                              template_folders=[]))
         with self.assertRaises(ValueError):
             splitter.split_data()
 
@@ -192,7 +230,10 @@ class NetCdfSplitterTest(unittest.TestCase):
         input_path = f'{self._data_dir}/era5_sample.nc'
         output_base = f'{self._data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
-                                  OutFileInfo(output_base, formatting='_{variable}', ending='.nc'))
+                                  OutFileInfo(output_base,
+                                              formatting='_{variable}',
+                                              ending='.nc',
+                                              template_folders=[]))
         self.assertFalse(splitter.should_skip())
         splitter.split_data()
         self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
@@ -203,7 +244,10 @@ class NetCdfSplitterTest(unittest.TestCase):
         output_base = f'{self._data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
                                   OutFileInfo(
-                                      output_base, formatting='_{variable}', ending='.nc'),
+                                      output_base,
+                                      formatting='_{variable}',
+                                      ending='.nc',
+                                      template_folders=[]),
                                   force_split=True)
         self.assertFalse(splitter.should_skip())
         splitter.split_data()
@@ -228,22 +272,12 @@ class DrySplitterTest(unittest.TestCase):
     def test_path_with_output_pattern_no_formatting(self):
         # OutFileInfo using pattern but without any formatting marks.
         splitter = DrySplitter("input_path/file.grib",
-                               OutFileInfo("some/out/no/formatting"))
+                               OutFileInfo("some/out/no/formatting",
+                                           formatting='',
+                                           ending='',
+                                           template_folders=[]))
         with self.assertRaises(ValueError):
             splitter.split_data()
-
-    def test_path_with_output_dir_no_formatting(self):
-        input_path = 'a/b/c/d/file.nc'
-        out_dir = 'gs://my_bucket/splits/'
-        out_info = get_output_file_info(
-            filename=input_path, input_base_dir='a/b/c/', out_dir=out_dir)
-        splitter = DrySplitter(input_path, out_info)
-        keys = splitter._get_keys()
-        self.assertEqual(
-            keys, {'default_for_filetype': 'default_for_filetype'})
-        out_file = splitter.output_info.formatted_output_path(keys)
-        self.assertEqual(
-            out_file, 'gs://my_bucket/splits/d/file_default_for_filetype.nc')
 
 
 if __name__ == '__main__':

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -80,7 +80,7 @@ class GribSplitterTest(unittest.TestCase):
             OutFileInfo(
                 file_name_template='path/output/file.{typeOfLevel}_{shortName}', ending='.grib')
         )
-        out = splitter._get_output_file_path(
+        out = splitter.output_info.formatted_output_path(
             {'typeOfLevel': 'surface', 'shortName': 'cc'})
         self.assertEqual(out, 'path/output/file.surface_cc.grib')
 
@@ -91,7 +91,7 @@ class GribSplitterTest(unittest.TestCase):
             OutFileInfo(file_name_template='path/output/file',
                         formatting='_{typeOfLevel}_{shortName}', ending='.grib')
         )
-        splitter._open_outfile(splitter._get_output_file_path(
+        splitter._open_outfile(splitter.output_info.formatted_output_path(
             {'typeOfLevel': 'surface', 'shortName': 'cc'}))
         mock_io.assert_called_with('path/output/file_surface_cc.grib')
 
@@ -166,7 +166,7 @@ class NetCdfSplitterTest(unittest.TestCase):
     def test_get_output_file_path(self):
         splitter = NetCdfSplitter(
             'path/to/input', OutFileInfo('path/output/file_{variable}', '.nc'))
-        out = splitter._get_output_file_path({'variable': 'cc'})
+        out = splitter.output_info.formatted_output_path({'variable': 'cc'})
         self.assertEqual(out, 'path/output/file_cc.nc')
 
     def test_split_data(self):
@@ -233,7 +233,7 @@ class DrySplitterTest(unittest.TestCase):
         splitter = DrySplitter(input_path, out_info)
         keys = splitter._get_keys()
         self.assertEqual(keys, {'variable': 'variable'})
-        out_file = splitter._get_output_file_path(keys)
+        out_file = splitter.output_info.formatted_output_path(keys)
         self.assertEqual(
             out_file, 'gs://my_bucket/splits/c-d-file_old_data.variable.cd')
 
@@ -251,7 +251,7 @@ class DrySplitterTest(unittest.TestCase):
         splitter = DrySplitter(input_path, out_info)
         keys = splitter._get_keys()
         self.assertEqual(keys, {'default_for_filetype': 'default_for_filetype'})
-        out_file = splitter._get_output_file_path(keys)
+        out_file = splitter.output_info.formatted_output_path(keys)
         self.assertEqual(
             out_file, 'gs://my_bucket/splits/d/file_default_for_filetype.nc')
 

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -39,6 +39,7 @@ def split_file(input_file: str,
                input_base_dir: str,
                output_template: t.Optional[str],
                output_dir: t.Optional[str],
+               formatting: str,
                dry_run: bool,
                force_split: bool = False):
     logger.info('Splitting file %s', input_file)
@@ -47,7 +48,8 @@ def split_file(input_file: str,
                             get_output_base_name(input_path=input_file,
                                                  input_base=input_base_dir,
                                                  output_template=output_template,
-                                                 output_dir=output_dir),
+                                                 output_dir=output_dir,
+                                                 formatting=formatting),
                             dry_run,
                             force_split)
     splitter.split_data()
@@ -64,8 +66,13 @@ def _get_base_input_directory(input_pattern: str) -> str:
 def get_output_base_name(input_path: str,
                          input_base: str,
                          output_template: t.Optional[str],
-                         output_dir: t.Optional[str]) -> OutFileInfo:
-    return get_output_file_info(input_path, input_base, output_template, output_dir)
+                         output_dir: t.Optional[str],
+                         formatting: str) -> OutFileInfo:
+    return get_output_file_info(input_path,
+                                input_base_dir=input_base,
+                                out_pattern=output_template,
+                                out_dir=output_dir,
+                                formatting=formatting)
 
 
 def run(argv: t.List[str], save_main_session: bool = True):
@@ -78,28 +85,28 @@ def run(argv: t.List[str], save_main_session: bool = True):
                         help='Pattern for input weather data.')
     output_options = parser.add_mutually_exclusive_group(required=True)
     output_options.add_argument(
-            '--output-template', type=str,
-            help='Template specifying path to output files using '
-                 'python-style formatting substitution of input '
-                 'directory names. '
-                 'For `input_pattern a/b/c/**` and file `a/b/c/file.grib`, '
-                 'a template with formatting `/somewhere/{1}-{0}.{level}_{shortName}.grib` '
-                 'will give `somewhere/c-file.level_shortName.grib`'
-                 )
+        '--output-template', type=str,
+        help='Template specifying path to output files using '
+        'python-style formatting substitution of input '
+        'directory names. '
+        'For `input_pattern a/b/c/**` and file `a/b/c/file.grib`, '
+        'a template with formatting `/somewhere/{1}-{0}.{level}_{shortName}.grib` '
+        'will give `somewhere/c-file.level_shortName.grib`'
+    )
     output_options.add_argument(
-            '--output-dir', type=str,
-            help='Output directory that will replace the common path of the '
-                 'input_pattern. '
-                 'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, '
-                 '`outputdir /x/y/z` will create '
-                 'output files like `/x/y/z/c/file_variable.nc`'
-                 )
+        '--output-dir', type=str,
+        help='Output directory that will replace the common path of the '
+        'input_pattern. '
+        'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, '
+        '`outputdir /x/y/z` will create '
+        'output files like `/x/y/z/c/file_variable.nc`'
+    )
     parser.add_argument(
-            '--formatting', type=str,
-            help='Used in combination with `output-dir`: specifies the how to '
-                 'split the data and format the output file. '
-                 'Example: `_{time}_{level}hPa`'
-                 )
+        '--formatting', type=str, default='',
+        help='Used in combination with `output-dir`: specifies the how to '
+        'split the data and format the output file. '
+        'Example: `_{time}_{level}hPa`'
+    )
     parser.add_argument('-d', '--dry-run', action='store_true', default=False,
                         help='Test the input file matching and the output file scheme without splitting.')
     parser.add_argument('-f', '--force', action='store_true', default=False,
@@ -114,6 +121,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
     input_base_dir = _get_base_input_directory(input_pattern)
     output_template = known_args.output_template
     output_dir = known_args.output_dir
+    formatting = known_args.formatting
 
     if not output_template and not output_dir:
         raise ValueError('No output specified')
@@ -128,15 +136,16 @@ def run(argv: t.List[str], save_main_session: bool = True):
     logger.debug('dry_run: %s', known_args.dry_run)
     with beam.Pipeline(options=pipeline_options) as p:
         (
-                p
-                | 'MatchFiles' >> MatchFiles(input_pattern)
-                | 'ReadMatches' >> ReadMatches()
-                | 'Shuffle' >> beam.Reshuffle()
-                | 'GetPath' >> beam.Map(lambda x: x.metadata.path)
-                | 'SplitFiles' >> beam.Map(split_file,
-                                           input_base_dir,
-                                           output_template,
-                                           output_dir,
-                                           dry_run,
-                                           known_args.force)
+            p
+            | 'MatchFiles' >> MatchFiles(input_pattern)
+            | 'ReadMatches' >> ReadMatches()
+            | 'Shuffle' >> beam.Reshuffle()
+            | 'GetPath' >> beam.Map(lambda x: x.metadata.path)
+            | 'SplitFiles' >> beam.Map(split_file,
+                                       input_base_dir,
+                                       output_template,
+                                       output_dir,
+                                       formatting,
+                                       dry_run,
+                                       known_args.force)
         )

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -94,7 +94,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
                  '`outputdir /x/y/z` will create '
                  'output files like `/x/y/z/c/file_variable.nc`'
                  )
-    output_options.add_argument(
+    parser.add_argument(
             '--formatting', type=str,
             help='Used in combination with `output-dir`: specifies the how to '
                  'split the data and format the output file. '

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -22,7 +22,7 @@ from apache_beam.io.fileio import MatchFiles, ReadMatches
 import apache_beam.metrics as metrics
 from apache_beam.options.pipeline_options import PipelineOptions, SetupOptions
 
-from .file_name_utils import OutFileInfo, get_output_file_base_name
+from .file_name_utils import OutFileInfo, get_output_file_info
 from .file_splitters import get_splitter
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ def get_output_base_name(input_path: str,
                          input_base: str,
                          output_template: t.Optional[str],
                          output_dir: t.Optional[str]) -> OutFileInfo:
-    return get_output_file_base_name(input_path, input_base, output_template, output_dir)
+    return get_output_file_info(input_path, input_base, output_template, output_dir)
 
 
 def run(argv: t.List[str], save_main_session: bool = True):
@@ -83,8 +83,8 @@ def run(argv: t.List[str], save_main_session: bool = True):
                  'python-style formatting substitution of input '
                  'directory names. '
                  'For `input_pattern a/b/c/**` and file `a/b/c/file.grib`, '
-                 'a template with formatting `/somewhere/{1}-{0}.{levelType}_{shortName}.grib` '
-                 'will give `somewhere/c-file.level_shortName.nc`'
+                 'a template with formatting `/somewhere/{1}-{0}.{level}_{shortName}.grib` '
+                 'will give `somewhere/c-file.level_shortName.grib`'
                  )
     output_options.add_argument(
             '--output-dir', type=str,
@@ -92,7 +92,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
                  'input_pattern. '
                  'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, '
                  '`outputdir /x/y/z` will create '
-                 'output files like `/x/y/z/c/file.shortname.nc`'
+                 'output files like `/x/y/z/c/file_variable.nc`'
                  )
     output_options.add_argument(
             '--formatting', type=str,

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -83,16 +83,22 @@ def run(argv: t.List[str], save_main_session: bool = True):
                  'python-style formatting substitution of input '
                  'directory names. '
                  'For `input_pattern a/b/c/**` and file `a/b/c/file.grib`, '
-                 'a template with formatting `/somewhere/{1}-{0}.{levelType}_{shortname}.grib` '
-                 'will give `somewhere/c-file.level_shortname.nc`'
+                 'a template with formatting `/somewhere/{1}-{0}.{levelType}_{shortName}.grib` '
+                 'will give `somewhere/c-file.level_shortName.nc`'
                  )
     output_options.add_argument(
             '--output-dir', type=str,
             help='Output directory that will replace the common path of the '
                  'input_pattern. '
                  'For `input_pattern a/b/c/**` and file `a/b/c/file.nc`, '
-                 '`output_template /x/y/z` will create '
+                 '`outputdir /x/y/z` will create '
                  'output files like `/x/y/z/c/file.shortname.nc`'
+                 )
+    output_options.add_argument(
+            '--formatting', type=str,
+            help='Used in combination with `output-dir`: specifies the how to '
+                 'split the data and format the output file. '
+                 'Example: `_{time}_{level}hPa`'
                  )
     parser.add_argument('-d', '--dry-run', action='store_true', default=False,
                         help='Test the input file matching and the output file scheme without splitting.')

--- a/weather_sp/splitter_pipeline/pipeline_test.py
+++ b/weather_sp/splitter_pipeline/pipeline_test.py
@@ -42,7 +42,7 @@ class PipelineTest(unittest.TestCase):
             input_path='somewhere/somefile',
             input_base='somewhere',
             output_template=None,
-            formatting='',
+            formatting='.{shortName}',
             output_dir='out/there').file_name_template, 'out/there/somefile')
 
     @patch('weather_sp.splitter_pipeline.file_splitters.get_splitter')
@@ -57,7 +57,8 @@ class PipelineTest(unittest.TestCase):
         mock_get_splitter.assert_called_with('somewhere/somefile',
                                              OutFileInfo('out/there/somefile',
                                                          formatting='_{variable}',
-                                                         ending=''),
+                                                         ending='',
+                                                         template_folders=[]),
                                              True)
 
 

--- a/weather_sp/splitter_pipeline/pipeline_test.py
+++ b/weather_sp/splitter_pipeline/pipeline_test.py
@@ -25,24 +25,25 @@ class PipelineTest(unittest.TestCase):
 
     def test_get_base_input_directory(self):
         self.assertEqual(
-                _get_base_input_directory(
-                    '/path/to/some/wild/*/card/??[0-1].nc'),
-                '/path/to/some')
+            _get_base_input_directory(
+                '/path/to/some/wild/*/card/??[0-1].nc'),
+            '/path/to/some')
         self.assertEqual(
-                _get_base_input_directory(
-                    '/path/to/some/wild/??/card/*[0-1].nc'),
-                '/path/to/some')
+            _get_base_input_directory(
+                '/path/to/some/wild/??/card/*[0-1].nc'),
+            '/path/to/some')
         self.assertEqual(
-                _get_base_input_directory(
-                    '/path/to/some/wild/201[8,9]/card/??.nc'),
-                '/path/to/some')
+            _get_base_input_directory(
+                '/path/to/some/wild/201[8,9]/card/??.nc'),
+            '/path/to/some')
 
     def test_get_output_base_name(self):
         self.assertEqual(get_output_base_name(
-                input_path='somewhere/somefile',
-                input_base='somewhere',
-                output_template=None,
-                output_dir='out/there').file_name_template, 'out/there/somefile')
+            input_path='somewhere/somefile',
+            input_base='somewhere',
+            output_template=None,
+            formatting='',
+            output_dir='out/there').file_name_template, 'out/there/somefile')
 
     @patch('weather_sp.splitter_pipeline.file_splitters.get_splitter')
     @unittest.skip('bad mocks')
@@ -51,9 +52,12 @@ class PipelineTest(unittest.TestCase):
                    input_base_dir='somewhere',
                    output_dir='out/there',
                    output_template=None,
+                   formatting='_{variable}',
                    dry_run=True)
         mock_get_splitter.assert_called_with('somewhere/somefile',
-                                             OutFileInfo('out/there/somefile_', ''),
+                                             OutFileInfo('out/there/somefile',
+                                                         formatting='_{variable}',
+                                                         ending=''),
                                              True)
 
 

--- a/weather_sp/splitter_pipeline/pipeline_test.py
+++ b/weather_sp/splitter_pipeline/pipeline_test.py
@@ -42,7 +42,7 @@ class PipelineTest(unittest.TestCase):
                 input_path='somewhere/somefile',
                 input_base='somewhere',
                 output_template=None,
-                output_dir='out/there').file_name_template, 'out/there/somefile.{levelType}{shortname}')
+                output_dir='out/there').file_name_template, 'out/there/somefile')
 
     @patch('weather_sp.splitter_pipeline.file_splitters.get_splitter')
     @unittest.skip('bad mocks')


### PR DESCRIPTION
Allow more flexible splitting.

Dimensions to split along are specified using output formatting to avoid mismatch between formatting and splitting.
Possible splits for GRIB files are all metadata fields, like shortName, typeOfLevel, date, time, step, forecastTime, etc.
Possible splits for NetCDF files are 'level', 'time', 'variable'. If the specified dimension (time, level) is not in the file, and exception will the thrown.

Output formatting can be given using an output template that contains formatting marks, or an output directory with an additional formatting string. If an output directory is specified without formatting, file type-specific defaults are used.
 
