### PR TITLE
Suppress urllib3 warning

### DIFF
--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -21,9 +21,14 @@ import json
 import logging
 import os
 import typing as t
+import urllib3
+import warnings
 
 import cdsapi
 from ecmwfapi import ECMWFService
+
+warnings.simplefilter(
+    "ignore", category=urllib3.connectionpool.InsecureRequestWarning)
 
 
 class Client(abc.ABC):


### PR DESCRIPTION
This comes from urllib3 through cdsapi. It spams logging output in local runs, but doesn't seem important.
Here's what it looks like:
```
urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'cds.climate.copernicus.eu'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  warnings.warn(
```