### PR TITLE
Robust download from clients to VMs.

### DIFF
--- a/weather_dl/download_pipeline/fetcher_test.py
+++ b/weather_dl/download_pipeline/fetcher_test.py
@@ -126,10 +126,8 @@ class FetchDataTest(unittest.TestCase):
             user='unknown',
         ), list(self.dummy_manifest.records.values())[0]._asdict())
 
-    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
     @patch('cdsapi.Client.retrieve')
-    def test_fetch_data__manifest__records_retrieve_failure(self, mock_retrieve,
-                                                            mock_gcs_file):
+    def test_fetch_data__manifest__records_retrieve_failure(self, mock_retrieve):
         config = {
             'parameters': {
                 'dataset': 'reanalysis-era5-pressure-levels',
@@ -166,8 +164,7 @@ class FetchDataTest(unittest.TestCase):
 
     @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
     @patch('cdsapi.Client.retrieve')
-    def test_fetch_data__manifest__records_gcs_failure(self, mock_retrieve,
-                                                       mock_gcs_file):
+    def test_fetch_data__manifest__records_gcs_failure(self, mock_retrieve, mock_gcs_file):
         config = {
             'parameters': {
                 'dataset': 'reanalysis-era5-pressure-levels',
@@ -200,3 +197,31 @@ class FetchDataTest(unittest.TestCase):
 
         self.assertIn(error.args[0], actual['error'])
         self.assertIn(error.args[0], e.exception.args[0])
+
+    @patch('weather_dl.download_pipeline.stores.InMemoryStore.open', return_value=io.StringIO())
+    @patch('cdsapi.Client.retrieve')
+    def test_fetch_data__skips_existing_download(self, mock_retrieve, mock_gcs_file):
+        config = {
+            'parameters': {
+                'dataset': 'reanalysis-era5-pressure-levels',
+                'partition_keys': ['year', 'month'],
+                'target_path': 'gs://weather-dl-unittest/download-{}-{}.nc',
+                'api_url': 'https//api-url.com/v1/',
+                'api_key': '12345',
+            },
+            'selection': {
+                'features': ['pressure'],
+                'month': ['12'],
+                'year': ['01']
+            }
+        }
+
+        # target file already exists in store...
+        store = InMemoryStore()
+        store.store['gs://weather-dl-unittest/download-01-12.nc'] = ''
+
+        fetcher = Fetcher('cds', self.dummy_manifest, store)
+        fetcher.fetch_data(config)
+
+        self.assertFalse(mock_gcs_file.called)
+        self.assertFalse(mock_retrieve.called)


### PR DESCRIPTION
This fixes #140 with a few tactics. First, I've added a check to skip a partition during the fetch step. Thus, if this step fails and restarts, it won't re-download from the beginning anymore. This functions as a fallback mechanism. Second, we add retry logic that will catch a common source of error: socket timeouts during download from remote servers. This should prevent the ParDo step from failing in the first place.

Thanks to @uhager for identifying this bug.