### PR TITLE
Unscheduling developer meetings.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,6 @@ submitting a change-list (CL).
 In general, we're happier reviewing many small PRs over fewer, larger changes. Please try to
 submit [small CLs](https://google.github.io/eng-practices/review/developer/small-cls.html).
 
-## Developer Meetings
-
-To facilitate internal and community support of weather tools, we invite you to join our regular developer meetings.
-Since our contributors are in a wide range of time zones, we offer two fortnightly meetings: Wednesdays at 8:30 AM PST
-and Fridays at 3:00 PM PST. Feel free to attend to only one meeting every two weeks, whichever best works with your
-schedule. Our first open meeting will occur on Friday, January 28th, 2022 (the first morning meeting will be held on
-Wednesday, February 2nd, 2022).
-
-[Here is a calendar](https://calendar.google.com/calendar/u/0?cid=Y19uYzJhNXVxMzE1ZnAzb2U1bWUwMGw2NTBxOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
-of our meeting schedule,
-and [here are our meeting notes](https://docs.google.com/document/d/1V2iISi-ZZNmrcImrPV7UYQGFNAe9XQ_-TB8iPggfmbo/edit).
-
 ## Project Structure
 
 ```


### PR DESCRIPTION
The resourcing for our project has changed; we have more internal contributors at this time than external. As a result, we plan on coordinating asynchronously with external contributors. In our experience over the past month, we found that meetings over video-chat were not that fruitful.

We can revisit reinstating these open meetings at a future time.