### PR TITLE
New Syntax for download configs: `day=all`

### DIFF
--- a/configs/era5_example_monthly_soil.cfg
+++ b/configs/era5_example_monthly_soil.cfg
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[parameters]
+client=cds
+dataset=reanalysis-era5-complete
+target_path=gs://ecmwf-output-test/era5/ERA5GRIB/HRES/Month/{year}/{year}{month:02d}_hres_soil.grb2
+partition_keys=
+    year
+    month
+
+[selection]
+class=ea
+stream=oper
+expver=1
+levtype=sfc
+type=an
+year=1979/1981
+month=1/to/12
+day=all
+time=00/to/23/by/1
+param=139.128/170.128/183.128/236.128/238.128/39.128/40.128/41.128/42.128/35.128/36.128/37.128/38.128

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -21,12 +21,13 @@ import json
 import logging
 import os
 import typing as t
-import urllib3
 import warnings
 
 import cdsapi
+import urllib3
 from ecmwfapi import ECMWFService
-from .config import Config
+
+from .config import Config, optimize_selection_partition
 
 warnings.simplefilter(
     "ignore", category=urllib3.connectionpool.InsecureRequestWarning)
@@ -100,7 +101,8 @@ class CdsClient(Client):
         )
 
     def retrieve(self, dataset: str, selection: t.Dict, target: str) -> None:
-        self.c.retrieve(dataset, selection, target)
+        selection_ = optimize_selection_partition(selection)
+        self.c.retrieve(dataset, selection_, target)
 
     @property
     def license_url(self):
@@ -184,8 +186,9 @@ class MarsClient(Client):
         )
 
     def retrieve(self, dataset: str, selection: t.Dict, output: str) -> None:
+        selection_ = optimize_selection_partition(selection)
         with StdoutLogger(self.logger, level=logging.DEBUG):
-            self.c.execute(req=selection, target=output)
+            self.c.execute(req=selection_, target=output)
 
     @property
     def license_url(self):

--- a/weather_dl/download_pipeline/config.py
+++ b/weather_dl/download_pipeline/config.py
@@ -74,7 +74,7 @@ class Config:
 
 
 def optimize_selection_partition(selection: t.Dict) -> t.Dict:
-    """Compute right-hand-side values for the selection section.
+    """Compute right-hand-side values for the selection section of a single partition.
 
     Used to support custom syntax and optimizations, such as 'all'.
     """

--- a/weather_dl/download_pipeline/config_test.py
+++ b/weather_dl/download_pipeline/config_test.py
@@ -79,7 +79,7 @@ class SelectionSyntaxTest(unittest.TestCase):
         selection_with_multiple_years = {'year': '2020/2021', 'month': '2', 'day': 'all'}
         with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
             optimize_selection_partition(selection_with_multiple_years)
-            j
+
         selection_with_multiple_years = {'year': ['2020/2021'], 'month': '2', 'day': 'all'}
         with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
             optimize_selection_partition(selection_with_multiple_years)

--- a/weather_dl/download_pipeline/config_test.py
+++ b/weather_dl/download_pipeline/config_test.py
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import calendar
+import copy
 import os
 import unittest
 
-from .pipeline import run
 import weather_dl
+from .config import optimize_selection_partition
+from .pipeline import run
 
 
 class ConfigTest(unittest.TestCase):
@@ -38,3 +40,63 @@ class ConfigTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class SelectionSyntaxTest(unittest.TestCase):
+
+    ALL_DAYS = [
+        ({'year': f'{y:04d}', 'month': f'{m:02d}', 'day': 'all'}, calendar.monthrange(y, m)[1])
+        for y in range(1900, 2023)
+        for m in range(1, 13)
+    ]
+
+    def test_all_days__as_strings(self):
+        for selection, n_days in self.ALL_DAYS:
+            year, month = selection["year"], selection["month"]
+            expected = f'{year}-{month}-01/to/{year}-{month}-{n_days:02d}'
+            with self.subTest(msg=f'{year}-{month} == {n_days}'):
+                actual = optimize_selection_partition(selection)
+                self.assertEqual(actual['date'], expected)
+                self.assertNotIn('day', actual)
+                self.assertNotIn('month', actual)
+                self.assertNotIn('year', actual)
+
+    def test_all_days__as_lists(self):
+        for selection_, n_days in self.ALL_DAYS:
+            selection = copy.deepcopy(selection_)
+            year, month = selection["year"], selection["month"]
+            expected = f'{year}-{month}-01/to/{year}-{month}-{n_days:02d}'
+            selection['year'] = [year]
+            selection['month'] = [month]
+            with self.subTest(msg=f'{year}-{month} == {n_days}'):
+                actual = optimize_selection_partition(selection)
+                self.assertEqual(actual['date'], expected)
+                self.assertNotIn('day', actual)
+                self.assertNotIn('month', actual)
+                self.assertNotIn('year', actual)
+
+    def test_all_days__invalid_year(self):
+        selection_with_multiple_years = {'year': '2020/2021', 'month': '2', 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
+            optimize_selection_partition(selection_with_multiple_years)
+            j
+        selection_with_multiple_years = {'year': ['2020/2021'], 'month': '2', 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
+            optimize_selection_partition(selection_with_multiple_years)
+
+        selection_with_multiple_years = {'year': ['2020', '2021'], 'month': '2', 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
+            optimize_selection_partition(selection_with_multiple_years)
+
+    def test_all_days__invalid_month(self):
+        selection_with_multiple_years = {'year': '2020', 'month': '1/2/3', 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'month's."):
+            optimize_selection_partition(selection_with_multiple_years)
+
+        selection_with_multiple_years = {'year': '2020', 'month': ['1/2/3'], 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'month's."):
+            optimize_selection_partition(selection_with_multiple_years)
+
+        selection_with_multiple_years = {'year': '2020', 'month': ['1', '2', '3'], 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'month's."):
+            optimize_selection_partition(selection_with_multiple_years)

--- a/weather_dl/download_pipeline/parsers.py
+++ b/weather_dl/download_pipeline/parsers.py
@@ -13,18 +13,19 @@
 # limitations under the License.
 """Parsers for ECMWF download configuration."""
 
+import ast
 import configparser
 import copy as cp
 import datetime
 import json
-import ast
 import string
 import textwrap
 import typing as t
-from .config import Config
-from urllib.parse import urlparse
 from collections import OrderedDict
+from urllib.parse import urlparse
+
 from .clients import CLIENTS
+from .config import Config
 from .manifest import MANIFESTS, Manifest, Location, NoOpManifest
 
 
@@ -401,6 +402,12 @@ def process_config(file: t.IO) -> Config:
             'target_path' has {0} replacements. Expected {1}, since there are {1}
             partition keys.
             """.format(num_template_replacements, num_partition_keys))
+
+    if 'day' in partition_keys:
+        require(selection['day'] != 'all',
+                """
+                If 'all' is used for a selection value, it cannot appear as a partition key. 
+                """)
 
     # Ensure consistent lookup.
     config['parameters']['partition_keys'] = partition_keys

--- a/weather_dl/download_pipeline/parsers.py
+++ b/weather_dl/download_pipeline/parsers.py
@@ -294,7 +294,7 @@ def _parse_lists(config_parser: configparser.ConfigParser, section: str = '') ->
 
 def _number_of_replacements(s: t.Text):
     format_names = [v[1] for v in string.Formatter().parse(s) if v[1] is not None]
-    num_empty_names = len([empty for empty in format_names if empty is ''])
+    num_empty_names = len([empty for empty in format_names if empty == ''])
     if num_empty_names != 0:
         num_empty_names -= 1
     return len(set(format_names)) + num_empty_names
@@ -405,9 +405,7 @@ def process_config(file: t.IO) -> Config:
 
     if 'day' in partition_keys:
         require(selection['day'] != 'all',
-                """
-                If 'all' is used for a selection value, it cannot appear as a partition key. 
-                """)
+                """If 'all' is used for a selection value, it cannot appear as a partition key.""")
 
     # Ensure consistent lookup.
     config['parameters']['partition_keys'] = partition_keys
@@ -446,5 +444,3 @@ def get_subsections(config: Config) -> t.List[t.Tuple[str, t.Dict]]:
     """
     return [(name, params) for name, params in config.kwargs.items()
             if isinstance(params, dict)] or [('default', {})]
-
-

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -394,7 +394,6 @@ class HelpersTest(unittest.TestCase):
                 self.assertEqual(actual, want)
 
 
-
 class SubsectionsTest(unittest.TestCase):
     def test_parses_config_subsections(self):
         config = {"parsers": {'a': 1, 'b': 2}, "parsers.1": {'b': 3}}

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -382,12 +382,17 @@ class ParseConfigTest(unittest.TestCase):
 
 class HelpersTest(unittest.TestCase):
 
+    CASES = [('', 0), ('{} blah', 1), ('{} {}', 2),
+             ('{0}, {1}', 2), ('%s hello', 0), ('hello {.2f}', 1),
+             ('ear5-{year}{year}-{month}', 2), ('era5-{year}/{year}-{}-{}', 3),
+             ('{year}{year}{year}{year}', 1)]
+
     def test_number_of_replacements(self):
-        for (s, want) in [('', 0), ('{} blah', 1), ('{} {}', 2),
-                          ('{0}, {1}', 2), ('%s hello', 0), ('hello {.2f}', 1)]:
+        for s, want in self.CASES:
             with self.subTest(s=s, want=want):
                 actual = _number_of_replacements(s)
                 self.assertEqual(actual, want)
+
 
 
 class SubsectionsTest(unittest.TestCase):

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import calendar
 import datetime
 import io
 import unittest
@@ -23,7 +22,7 @@ from .parsers import (
     process_config,
     _number_of_replacements,
     parse_subsections,
-    prepare_target_name, substitute_selection_partition,
+    prepare_target_name,
 )
 from .config import Config
 
@@ -833,33 +832,6 @@ class PrepareTargetNameTest(unittest.TestCase):
             with self.subTest(msg=it['case'], **it):
                 actual = prepare_target_name(Config.from_dict(it['config']))
                 self.assertEqual(actual, it['expected'])
-
-
-class SelectionSyntaxTest(unittest.TestCase):
-
-    ALL_DAYS = [
-        ({'year': f'{y:04d}', 'month': f'{m:02d}', 'day': 'all'}, calendar.monthrange(y, m)[1])
-        for m in range(1, 13)
-        for y in range(1900, 2023)
-    ]
-
-    def test_all_days(self):
-        for selection, n_days in self.ALL_DAYS:
-            year, month = selection["year"], selection["month"]
-            with self.subTest(msg=f'{year}-{month} == {n_days}'):
-                actual = substitute_selection_partition(selection)
-                expected = f'{year}-{month}-01/to/{year}-{month}-{n_days:02d}'
-                self.assertEqual(actual['day'], expected)
-
-    def test_all_days__invalid_year(self):
-        selection_with_multiple_years = {'year': '2020/2021', 'month': '2', 'day': 'all'}
-        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
-            substitute_selection_partition(selection_with_multiple_years)
-
-    def test_all_days__invalid_month(self):
-        selection_with_multiple_years = {'year': '2020', 'month': '1/2/3', 'day': 'all'}
-        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'month's."):
-            substitute_selection_partition(selection_with_multiple_years)
 
 
 if __name__ == '__main__':

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -736,6 +736,28 @@ class ProcessConfigTest(unittest.TestCase):
             "Invalid 'client' parameter.",
             ctx.exception.args[0])
 
+    def test_partition_cannot_include_all(self):
+        with self.assertRaisesRegex(ValueError, 'cannot appear as a partition key.'):
+            with io.StringIO(
+                    """
+                    [parameters]
+                    dataset=foo
+                    client=cds
+                    target_path=bar-{}-{}
+                    partition_keys=
+                        month
+                        day
+                    [selection]
+                    year=2012
+                    month=
+                        01
+                        02
+                        03
+                    day=all
+                    """
+            ) as f:
+                process_config(f)
+
 
 class PrepareTargetNameTest(unittest.TestCase):
     TEST_CASES = [

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import calendar
 import datetime
 import io
 import unittest
@@ -23,7 +23,7 @@ from .parsers import (
     process_config,
     _number_of_replacements,
     parse_subsections,
-    prepare_target_name,
+    prepare_target_name, substitute_selection_partition,
 )
 from .config import Config
 
@@ -833,6 +833,33 @@ class PrepareTargetNameTest(unittest.TestCase):
             with self.subTest(msg=it['case'], **it):
                 actual = prepare_target_name(Config.from_dict(it['config']))
                 self.assertEqual(actual, it['expected'])
+
+
+class SelectionSyntaxTest(unittest.TestCase):
+
+    ALL_DAYS = [
+        ({'year': f'{y:04d}', 'month': f'{m:02d}', 'day': 'all'}, calendar.monthrange(y, m)[1])
+        for m in range(1, 13)
+        for y in range(1900, 2023)
+    ]
+
+    def test_all_days(self):
+        for selection, n_days in self.ALL_DAYS:
+            year, month = selection["year"], selection["month"]
+            with self.subTest(msg=f'{year}-{month} == {n_days}'):
+                actual = substitute_selection_partition(selection)
+                expected = f'{year}-{month}-01/to/{year}-{month}-{n_days:02d}'
+                self.assertEqual(actual['day'], expected)
+
+    def test_all_days__invalid_year(self):
+        selection_with_multiple_years = {'year': '2020/2021', 'month': '2', 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'year's."):
+            substitute_selection_partition(selection_with_multiple_years)
+
+    def test_all_days__invalid_month(self):
+        selection_with_multiple_years = {'year': '2020', 'month': '1/2/3', 'day': 'all'}
+        with self.assertRaisesRegex(AssertionError, "Cannot use keyword .* 'month's."):
+            substitute_selection_partition(selection_with_multiple_years)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR helps address the use case where one wants to download data a month at a time. This is somewhat possible in the downloader currently, where users partition by `year` and `month`. However, there is no way to specify a variable number of days (which is dependent on the rest of the date). Thus, this syntax was borne. 

In implementing this feature, I discovered that the CDS API has dataset-dependent keywords. Not all datasets include `day` as an allowed keyword. If they do, it's possible that the request will face a "ambiguous request" error. To better support all days, this PR introduces an optimization, where year/month partitions will be internally transformed to date-ranges upon request. 

The `config.py` class now includes a selection section optimization function that can be used in the future for other just-in-time improvements to download requests.  