### PR TITLE
Fix parsing newline separated date values

### DIFF
--- a/weather_dl/download_pipeline/parsers.py
+++ b/weather_dl/download_pipeline/parsers.py
@@ -287,7 +287,7 @@ def _parse_lists(config_parser: configparser.ConfigParser, section: str = '') ->
     config = dict(config_parser.items(section))
 
     for key, val in config.items():
-        if ('/' in val or key == 'date') and 'parameters' not in section:
+        if '/' in val and 'parameters' not in section:
             config[key] = parse_mars_syntax(val)
         elif '\n' in val:
             config[key] = _splitlines(val)

--- a/weather_dl/setup.py
+++ b/weather_dl/setup.py
@@ -32,7 +32,7 @@ base_requirements = [
 setup(
     name='download_pipeline',
     packages=find_packages(),
-    version='0.1.6',
+    version='0.1.7',
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
     url='https://weather-tools.readthedocs.io/en/latest/weather_dl/',


### PR DESCRIPTION
Fixes #157.

Removed the check of `key == 'date'` from `_parse_lists` method as it was originally introduced to fix #114. But this got handled in much better way after fixing #152.
