### PR TITLE
Refactored weather-mv code to fix memory issue.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ weather_mv_requirements = [
     "cfgrib",
     "netcdf4",
     "geojson",
+    "more-itertools",
     "simplejson",
     "rioxarray",
     "rasterio",

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -16,7 +16,6 @@ import dataclasses
 import datetime
 import json
 import logging
-import math
 import os
 import signal
 import sys
@@ -30,20 +29,21 @@ from urllib.parse import urlparse
 
 import apache_beam as beam
 import geojson
+import more_itertools as mitertools
 import numpy as np
-import pandas as pd
 import xarray as xr
 from apache_beam.io import WriteToBigQuery, BigQueryDisposition
 from apache_beam.options.pipeline_options import PipelineOptions
 from google.api_core.exceptions import BadRequest
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery, storage
+from xarray.core.utils import ensure_us_time_resolution
 
 from .sinks import ToDataSink, open_dataset
 from .util import (
     to_json_serializable_type,
     _only_target_vars,
-    _only_target_coordinate_vars
+    get_coordinates
 )
 
 logger = logging.getLogger(__name__)
@@ -205,14 +205,20 @@ class ToBigQuery(ToDataSink):
                     prepare_coordinates,
                     coordinate_chunk_size=self.coordinate_chunk_size,
                     area=self.area,
-                    import_time=self.import_time,
                     open_dataset_kwargs=self.xarray_open_dataset_kwargs,
                     variables=self.variables,
                     disable_in_memory_copy=self.disable_in_memory_copy,
                     disable_grib_schema_normalization=self.disable_grib_schema_normalization,
                     tif_metadata_for_datetime=self.tif_metadata_for_datetime)
                 | beam.Reshuffle()
-                | 'ExtractRows' >> beam.FlatMapTuple(extract_rows)
+                | 'ExtractRows' >> beam.FlatMapTuple(
+                    extract_rows,
+                    variables=self.variables,
+                    import_time=self.import_time,
+                    open_dataset_kwargs=self.xarray_open_dataset_kwargs,
+                    disable_in_memory_copy=self.disable_in_memory_copy,
+                    disable_grib_schema_normalization=self.disable_grib_schema_normalization,
+                    tif_metadata_for_datetime=self.tif_metadata_for_datetime)
         )
 
         if not self.dry_run:
@@ -284,11 +290,10 @@ def prepare_coordinates(
         coordinate_chunk_size: int,
         variables: t.Optional[t.List[str]] = None,
         area: t.Optional[t.List[int]] = None,
-        import_time: t.Optional[str] = DEFAULT_IMPORT_TIME,
         open_dataset_kwargs: t.Optional[t.Dict] = None,
         disable_in_memory_copy: bool = False,
         disable_grib_schema_normalization: bool = False,
-        tif_metadata_for_datetime: t.Optional[str] = None) -> t.Iterator[t.Tuple[str, str, str, pd.DataFrame]]:
+        tif_metadata_for_datetime: t.Optional[str] = None) -> t.Iterator[t.Tuple[str, t.List[t.Dict]]]:
     """Open the dataset, filter by area, and prepare chunks of coordinates for parallel ingestion into BigQuery."""
     logger.info(f'Preparing coordinates for: {uri!r}.')
 
@@ -300,59 +305,59 @@ def prepare_coordinates(
             data_ds = data_ds.sel(latitude=slice(n, s), longitude=slice(w, e))
             logger.info(f'Data filtered by area, size: {data_ds.nbytes}')
 
-        # Re-calculate import time for streaming extractions.
-        if not import_time:
-            import_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+        for chunk in mitertools.ichunked(get_coordinates(data_ds, uri), coordinate_chunk_size):
+            yield uri, list(chunk)
+
+
+def extract_rows(uri: str,
+                 coordinates: t.List[t.Dict],
+                 variables: t.Optional[t.List[str]] = None,
+                 import_time: t.Optional[str] = DEFAULT_IMPORT_TIME,
+                 open_dataset_kwargs: t.Optional[t.Dict] = None,
+                 disable_in_memory_copy: bool = False,
+                 disable_grib_schema_normalization: bool = False,
+                 tif_metadata_for_datetime: t.Optional[str] = None) -> t.Iterator[t.Dict]:
+    """Reads an asset and coordinates, then yields its rows as a mapping of column names to values."""
+    logger.info(f'Extracting rows for [{coordinates[0]!r}...{coordinates[-1]!r}] of {uri!r}.')
+
+    # Re-calculate import time for streaming extractions.
+    if not import_time:
+        import_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+
+    with open_dataset(uri, open_dataset_kwargs, disable_in_memory_copy, disable_grib_schema_normalization,
+                      tif_metadata_for_datetime) as ds:
+        data_ds: xr.Dataset = _only_target_vars(ds, variables)
 
         first_ts_raw = data_ds.time[0].values if isinstance(data_ds.time.values, np.ndarray) else data_ds.time.values
         first_time_step = to_json_serializable_type(first_ts_raw)
 
-        # Add coordinates for 0-dimension file.
-        if len(data_ds.to_array().shape) == 1:
-            for coord in data_ds.coords:
-                data_ds = data_ds.assign_coords({coord: [data_ds[coord].values]})
+        for it in coordinates:
+            # Use those index values to select a Dataset containing one row of data.
+            row_ds = data_ds.loc[it]
 
-        df = data_ds.to_dataframe().reset_index()
+            # Create a Name-Value map for data columns. Result looks like:
+            # {'d': -2.0187, 'cc': 0.007812, 'z': 50049.8, 'rr': None}
+            row = {n: to_json_serializable_type(ensure_us_time_resolution(v.values))
+                   for n, v in row_ds.data_vars.items()}
 
-        # Add un-indexed coordinates and drop unwanted variables.
-        if variables:
-            indices = list(ds.coords.indexes.keys())
-            to_keep = _only_target_coordinate_vars(ds, variables) + indices
-            to_drop = set(df.columns) - set(to_keep)
-            df.drop(to_drop, axis=1, inplace=True)
+            # Add indexed coordinates.
+            row.update(it)
+            # Add un-indexed coordinates.
+            for c in row_ds.coords:
+                if c not in it and (not variables or c in variables):
+                    row[c] = to_json_serializable_type(ensure_us_time_resolution(row_ds[c].values))
 
-        num_chunks = math.ceil(len(df) / coordinate_chunk_size)
-        for i in range(num_chunks):
-            chunk = df[i * coordinate_chunk_size:(i + 1) * coordinate_chunk_size]
-            yield uri, import_time, first_time_step, chunk
+            # Add import metadata.
+            row[DATA_IMPORT_TIME_COLUMN] = import_time
+            row[DATA_URI_COLUMN] = uri
+            row[DATA_FIRST_STEP] = first_time_step
+            row[GEO_POINT_COLUMN] = fetch_geo_point(row['latitude'], row['longitude'])
 
-
-def _convert_time(val) -> t.Any:
-    """Converts pandas Timestamp values to ISO format."""
-    if isinstance(val, pd.Timestamp):
-        return val.replace(tzinfo=datetime.timezone.utc).isoformat()
-    elif isinstance(val, pd.Timedelta):
-        return val.total_seconds()
-    else:
-        return val
-
-
-def extract_rows(uri: str,
-                 import_time: str,
-                 first_time_step: str,
-                 rows: pd.DataFrame) -> t.Iterator[t.Dict]:
-    """Reads an asset and coordinates, then yields its rows as a mapping of column names to values."""
-    for _, row in rows.iterrows():
-        row = row.astype(object).where(pd.notnull(row), None)
-        row = {k: _convert_time(v) for k, v in row.iteritems()}
-
-        row[DATA_IMPORT_TIME_COLUMN] = import_time
-        row[DATA_URI_COLUMN] = uri
-        row[DATA_FIRST_STEP] = first_time_step
-        row[GEO_POINT_COLUMN] = fetch_geo_point(row['latitude'], row['longitude'])
-
-        beam.metrics.Metrics.counter('Success', 'ExtractRows').inc()
-        yield row
+            # 'row' ends up looking like:
+            # {'latitude': 88.0, 'longitude': 2.0, 'time': '2015-01-01 06:00:00', 'd': -2.0187, 'cc': 0.007812,
+            #  'z': 50049.8, 'data_import_time': '2020-12-05 00:12:02.424573 UTC', ...}
+            beam.metrics.Metrics.counter('Success', 'ExtractRows').inc()
+            yield row
 
 
 def _cleanup(bigquery_client: bigquery.Client, storage_client: storage.Client, canary_output_table: str,

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -196,12 +196,15 @@ class ExtractRowsTestBase(TestDataBase):
     def extract(self, data_path, *, variables=None, area=None, open_dataset_kwargs=None,
                 import_time=DEFAULT_IMPORT_TIME, disable_grib_schema_normalization=False,
                 tif_metadata_for_datetime=None) -> t.Iterator[t.Dict]:
-        coords = prepare_coordinates(data_path, coordinate_chunk_size=1000, area=area, import_time=import_time,
+        coords = prepare_coordinates(data_path, coordinate_chunk_size=1000, area=area,
                                      open_dataset_kwargs=open_dataset_kwargs, variables=variables,
                                      disable_grib_schema_normalization=disable_grib_schema_normalization,
                                      tif_metadata_for_datetime=tif_metadata_for_datetime)
-        for uri, import_time, first_time_step, chunk in coords:
-            yield from extract_rows(uri, import_time=import_time, first_time_step=first_time_step, rows=chunk)
+        for uri, chunk in coords:
+            yield from extract_rows(uri, import_time=import_time, open_dataset_kwargs=open_dataset_kwargs,
+                                    coordinates=chunk, variables=variables,
+                                    disable_grib_schema_normalization=disable_grib_schema_normalization,
+                                    tif_metadata_for_datetime=tif_metadata_for_datetime)
 
     def assertGeopointEqual(self, actual: str, expected: str) -> None:
         expected_json, actual_json = geojson.loads(expected), geojson.loads(actual)

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -38,6 +38,7 @@ base_requirements = [
     "cfgrib",
     "netcdf4",
     "geojson",
+    "more-itertools",
     "simplejson",
     "rioxarray",
     "metview",

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -133,7 +133,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.2',
+    version='0.2.3',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=base_requirements,


### PR DESCRIPTION
In the current version of code (without this fix), we try to convert xArray.Dataset into pandas.DataFrame (basically this will attempt to load complete dataset in-memory). So as a result OOM killer is invoked in case of working with a large file (eg: 22G). 

`e2e` bench-marking results:
- Single 260K records file - 
Current Version (without the fix) : ~10.43 min
Fixed Code: ~11 min
- Ten 260K records file -
Current Version (without the fix) : ~16.5 min
Fixed Code: ~18.11 min
