### PR TITLE
Mv fix regrid leak

### DIFF
--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -88,18 +88,18 @@ class Regrid(ToDataSink):
                 raise ImportError('Please install MetView with Anaconda:\n'
                                   '`conda install metview-batch -c conda-forge`') from e
 
-        with tempfile.NamedTemporaryFile() as src:
-            logger.debug(f'Writing {self.target_from(uri)!r} to local disk.')
-            if self.to_netcdf:
-                fieldset.to_dataset().to_netcdf(src.name)
-            else:
-                mv.write(src.name, fieldset)
+            with tempfile.NamedTemporaryFile() as src:
+                logger.debug(f'Writing {self.target_from(uri)!r} to local disk.')
+                if self.to_netcdf:
+                    fieldset.to_dataset().to_netcdf(src.name)
+                else:
+                    mv.write(src.name, fieldset)
 
-            src.flush()
+                src.flush()
 
-            logger.info(f'Uploading {self.target_from(uri)!r}.')
-            with FileSystems().create(self.target_from(uri)) as dst:
-                shutil.copyfileobj(src, dst, WRITE_CHUNK_SIZE)
+                logger.info(f'Uploading {self.target_from(uri)!r}.')
+                with FileSystems().create(self.target_from(uri)) as dst:
+                    shutil.copyfileobj(src, dst, WRITE_CHUNK_SIZE)
 
     def expand(self, paths):
         paths | beam.Map(self.apply)

--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import argparse
 import dataclasses
-import glob
 import json
 import logging
 import os.path
@@ -73,6 +72,8 @@ class Regrid(ToDataSink):
         return f'{no_ext}.nc'
 
     def apply(self, uri: str):
+        import glob
+
         logger.info(f'Regridding from {uri!r} to {self.target_from(uri)!r}.')
 
         if self.dry_run:

--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -82,7 +82,8 @@ class Regrid(ToDataSink):
             # TODO(alxr): Figure out way to open fieldset in memory...
             logger.debug(f'Regridding {uri!r}.')
             try:
-                fieldset = mv.read(source=local_grib, **self.regrid_kwargs)
+                fs = mv.Fieldset(path=local_grib)
+                fieldset = mv.regrid(data=fs, **self.regrid_kwargs)
             except (ModuleNotFoundError, ImportError, FileNotFoundError) as e:
                 raise ImportError('Please install MetView with Anaconda:\n'
                                   '`conda install metview-batch -c conda-forge`') from e


### PR DESCRIPTION
Fixed bug where the glob module needs to be imported inside the apply() to work properly with beam (for reasons I don't totally understand).