### PR TITLE
Added check for ee setup on retries.

### DIFF
--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -130,7 +130,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.3',
+    version='0.2.4',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=base_requirements,


### PR DESCRIPTION
When the pipeline tries to ingest into EE, if it fails due to rate-limit then on the next try (on different worker I believe), the ee is may not be initialized. This happens only when rate-limits cause a failure in ingestion and pipeline retries.
It was introduced after adding the rate-limit functionality.

The fix here is to maintain a has_setup flag.