### PR TITLE
Zarr-to-Zarr regridding with MetView.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
   - pandas=1.5.1
   - pip=22.3
   - pygrib=2.1.4
+  - gcsfs=2022.11.0
   - pip:
     - earthengine-api==0.1.329
     - .[test]

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - pip=22.3
   - pygrib=2.1.4
   - gcsfs=2022.11.0
+  - xarray-beam=0.3.1
   - pip:
     - earthengine-api==0.1.329
     - .[test]

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ weather_mv_requirements = [
     "pyproj",  # requires separate binary installation!
     "gdal",  # requires separate binary installation!
     "xarray-beam==0.3.1",
+    "gcsfs==2022.11.0",
 ]
 
 weather_sp_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ weather_mv_requirements = [
     "earthengine-api>=0.1.263",
     "pyproj",  # requires separate binary installation!
     "gdal",  # requires separate binary installation!
+    "xarray-beam==0.3.1",
 ]
 
 weather_sp_requirements = [

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -135,6 +135,8 @@ class ToBigQuery(ToDataSink):
         if known_args.area:
             assert len(known_args.area) == 4, 'Must specify exactly 4 lat/long values for area: N, W, S, E boundaries.'
 
+        assert not known_args.zarr, 'Reading Zarr is not (yet) supported.'
+
         # Check that all arguments are supplied for COG input.
         _, uri_extension = os.path.splitext(known_args.uris)
         if uri_extension == '.tif' and not known_args.tif_metadata_for_datetime:

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -64,7 +64,6 @@ class ToBigQuery(ToDataSink):
     `these docs`_ for more.
 
     Attributes:
-        example_uri: URI to a weather data file, used to infer the BigQuery schema.
         output_table: The destination for where data should be written in BigQuery
         variables: Target variables (or coordinates) for the BigQuery schema. By default,
           all data variables will be imported as columns.
@@ -86,7 +85,6 @@ class ToBigQuery(ToDataSink):
 
     .. _these docs: https://beam.apache.org/documentation/io/built-in/google-bigquery/#setting-the-insertion-method
     """
-    example_uri: str
     output_table: str
     variables: t.List[str]
     area: t.Tuple[int, int, int, int]
@@ -154,7 +152,7 @@ class ToBigQuery(ToDataSink):
 
     def __post_init__(self):
         """Initializes Sink by creating a BigQuery table based on user input."""
-        with open_dataset(self.example_uri, self.xarray_open_dataset_kwargs,
+        with open_dataset(self.first_uri, self.xarray_open_dataset_kwargs,
                           self.disable_grib_schema_normalization, self.tif_metadata_for_datetime) as open_ds:
             # Define table from user input
             if self.variables and not self.infer_schema and not open_ds.attrs['is_normalized']:

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -133,7 +133,8 @@ class ToBigQuery(ToDataSink):
         if known_args.area:
             assert len(known_args.area) == 4, 'Must specify exactly 4 lat/long values for area: N, W, S, E boundaries.'
 
-        assert not known_args.zarr, 'Reading Zarr is not (yet) supported.'
+        if known_args.zarr:
+            raise RuntimeError('Reading Zarr is not (yet) supported.')
 
         # Check that all arguments are supplied for COG input.
         _, uri_extension = os.path.splitext(known_args.uris)

--- a/weather_mv/loader_pipeline/ee.py
+++ b/weather_mv/loader_pipeline/ee.py
@@ -261,7 +261,8 @@ class ToEarthEngine(ToDataSink):
         pipeline_options = PipelineOptions(pipeline_args)
         pipeline_options_dict = pipeline_options.get_all_options()
 
-        assert not known_args.zarr, 'Reading Zarr is not (yet) supported.'
+        if known_args.zarr:
+            raise RuntimeError('Reading Zarr is not (yet) supported.')
 
         # Check that ee_asset is in correct format.
         if not re.match("^projects/.+/assets.*", known_args.ee_asset):

--- a/weather_mv/loader_pipeline/ee.py
+++ b/weather_mv/loader_pipeline/ee.py
@@ -261,6 +261,8 @@ class ToEarthEngine(ToDataSink):
         pipeline_options = PipelineOptions(pipeline_args)
         pipeline_options_dict = pipeline_options.get_all_options()
 
+        assert not known_args.zarr, 'Reading Zarr is not (yet) supported.'
+
         # Check that ee_asset is in correct format.
         if not re.match("^projects/.+/assets.*", known_args.ee_asset):
             raise RuntimeError("'--ee_asset' is required to be in format: projects/+/assets/*.")

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -54,8 +54,9 @@ def pipeline(known_args: argparse.Namespace, pipeline_args: t.List[str]) -> None
     known_args.first_uri = next(iter(all_uris))
 
     with beam.Pipeline(argv=pipeline_args) as p:
-        # TODO(alxr): Consider having a separate branch for Zarr files.
-        if known_args.topic:
+        if known_args.zarr:
+            paths = p
+        elif known_args.topic:
             paths = (
                     p
                     # Windowing is based on this code sample:
@@ -70,7 +71,7 @@ def pipeline(known_args: argparse.Namespace, pipeline_args: t.List[str]) -> None
         if known_args.subcommand == 'bigquery' or known_args.subcommand == 'bq':
             paths | "MoveToBigQuery" >> ToBigQuery.from_kwargs(**vars(known_args))
         elif known_args.subcommand == 'regrid' or known_args.subcommand == 'rg':
-            paths | "Regrid" >> Regrid.from_kwargs(pipeline=p, **vars(known_args))
+            paths | "Regrid" >> Regrid.from_kwargs(**vars(known_args))
         elif known_args.subcommand == 'earthengine' or known_args.subcommand == 'ee':
             paths | "MoveToEarthEngine" >> ToEarthEngine.from_kwargs(**vars(known_args))
         else:

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -102,7 +102,7 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
     base.add_argument('--zarr', action='store_true', default=False,
                       help="Treat the input URI as a Zarr. If the URI ends with '.zarr', this will be set to True. "
                            "Default: off")
-    base.add_argument('--zarr_kwargs', type=json.loads, default='{"chunks": null, "consolidated": true}',
+    base.add_argument('--zarr_kwargs', type=json.loads, default='{}',
                       help='Keyword arguments to pass into `xarray.open_zarr()`, as a JSON string. '
                            'Default: `{"chunks": null, "consolidated": true}`.')
     base.add_argument('-d', '--dry-run', action='store_true', default=False,

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -38,7 +38,8 @@ def configure_logger(verbosity: int) -> None:
 
 def pattern_to_uris(match_pattern: str, is_zarr: bool = False) -> t.Iterable[str]:
     if is_zarr:
-        return [match_pattern]
+        yield match_pattern
+        return
 
     for match in FileSystems().match([match_pattern]):
         yield from [x.path for x in match.metadata_list]
@@ -69,7 +70,7 @@ def pipeline(known_args: argparse.Namespace, pipeline_args: t.List[str]) -> None
         if known_args.subcommand == 'bigquery' or known_args.subcommand == 'bq':
             paths | "MoveToBigQuery" >> ToBigQuery.from_kwargs(**vars(known_args))
         elif known_args.subcommand == 'regrid' or known_args.subcommand == 'rg':
-            paths | "Regrid" >> Regrid.from_kwargs(**vars(known_args))
+            paths | "Regrid" >> Regrid.from_kwargs(pipeline=p, **vars(known_args))
         elif known_args.subcommand == 'earthengine' or known_args.subcommand == 'ee':
             paths | "MoveToEarthEngine" >> ToEarthEngine.from_kwargs(**vars(known_args))
         else:

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -14,8 +14,8 @@
 import json
 import unittest
 
-from .pipeline import run, pipeline
 import weather_mv
+from .pipeline import run, pipeline
 
 
 class CLITests(unittest.TestCase):
@@ -118,8 +118,9 @@ class TestCLI(CLITests):
     def test_rg_zarr_cant_output_netcdf(self):
         with self.assertRaisesRegex(ValueError, 'only Zarr-to-Zarr'):
             run(self.rg_cli_args + '--zarr --to_netcdf'.split())
+
     def test_rg_happy_path(self):
-            run(self.rg_cli_args + ['--zarr'])
+        run(self.rg_cli_args + ['--zarr'])
 
     def test_zarr_kwargs_must_come_with_zarr(self):
         with self.assertRaisesRegex(ValueError, 'allowed with valid Zarr input URI'):

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -117,9 +117,9 @@ class TestCLI(CLITests):
         with self.assertRaisesRegex(ValueError, 'only Zarr-to-Zarr'):
             run(self.rg_cli_args + '--zarr --to_netcdf'.split())
 
-    def test_zarr_chunks_must_come_with_zarr(self):
+    def test_zarr_kwargs_must_come_with_zarr(self):
         with self.assertRaisesRegex(ValueError, 'allowed with valid Zarr input URI'):
-            run(self.base_cli_args + ['--zarr_chunks', json.dumps({"time": 100})])
+            run(self.base_cli_args + ['--zarr_kwargs', json.dumps({"time": 100})])
 
 
 class IntegrationTest(CLITests):

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -108,16 +108,18 @@ class TestCLI(CLITests):
         self.assertEqual(known_args.xarray_open_dataset_kwargs, xarray_kwargs)
 
     def test_bq_does_not_yet_support_zarr(self):
-        with self.assertRaisesRegex(AssertionError, 'Reading Zarr'):
+        with self.assertRaisesRegex(RuntimeError, 'Reading Zarr'):
             run(self.base_cli_args + '--zarr'.split())
 
     def test_ee_does_not_yet_support_zarr(self):
-        with self.assertRaisesRegex(AssertionError, 'Reading Zarr'):
+        with self.assertRaisesRegex(RuntimeError, 'Reading Zarr'):
             run(self.ee_cli_args + '--zarr'.split())
 
     def test_rg_zarr_cant_output_netcdf(self):
         with self.assertRaisesRegex(ValueError, 'only Zarr-to-Zarr'):
             run(self.rg_cli_args + '--zarr --to_netcdf'.split())
+    def test_rg_happy_path(self):
+            run(self.rg_cli_args + ['--zarr'])
 
     def test_zarr_kwargs_must_come_with_zarr(self):
         with self.assertRaisesRegex(ValueError, 'allowed with valid Zarr input URI'):

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -35,6 +35,12 @@ class CLITests(unittest.TestCase):
             '--import_time 2022-02-04T22:22:12.125893 '
             '-s'
         ).split()
+        self.ee_cli_args = (
+            'weather-mv ee '
+            '-i weather_mv/test_data/test_data_2018*.nc '
+            '--asset_location gs://bucket/my-assets/ '
+            '--ee_asset "projects/my-project/assets/asset_dir'
+        ).split()
         self.base_cli_known_args = {
             'subcommand': 'bq',
             'uris': f'{self.test_data_folder}/test_data_2018*.nc',
@@ -94,6 +100,13 @@ class TestCLI(CLITests):
         )
         self.assertEqual(known_args.xarray_open_dataset_kwargs, xarray_kwargs)
 
+    def test_bq_does_not_yet_support_zarr(self):
+        with self.assertRaisesRegex(AssertionError, 'Reading Zarr'):
+            run(self.base_cli_args + ['--zarr'])
+
+    def test_ee_does_not_yet_support_zarr(self):
+        with self.assertRaisesRegex(AssertionError, 'Reading Zarr'):
+            run(self.ee_cli_args + ['--zarr'])
 
 class IntegrationTest(CLITests):
     def test_dry_runs_are_allowed(self):

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -62,6 +62,8 @@ class CLITests(unittest.TestCase):
             'coordinate_chunk_size': 10_000,
             'disable_grib_schema_normalization': False,
             'tif_metadata_for_datetime': None,
+            'zarr': False,
+            'zarr_kwargs': {},
         }
 
 

--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -177,7 +177,6 @@ class Regrid(ToDataSink):
         with _metview_op():
             # mv.dataset_to_fieldset will error on input where there is only 1 value in
             # a dimension. This has to do with ECMWF's cfgrib being in a alpha version.
-            # Thus, we take an alternative route to writing an XArray dataset to grib...
             try:
                 fs = mv.dataset_to_fieldset(ds)
                 regridded = mv.regrid(data=fs, **self.regrid_kwargs)

--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -82,6 +82,7 @@ class Regrid(ToDataSink):
     to_netcdf: bool = False
     zarr_input_chunks: t.Optional[t.Dict] = None
     zarr_output_chunks: t.Optional[t.Dict] = None
+    pipeline: t.Optional[beam.Pipeline] = None
 
     def __post_init__(self):
         if not self.zarr_input_chunks:
@@ -224,7 +225,7 @@ class Regrid(ToDataSink):
         source_ds = xr.open_zarr(self.first_uri, **self.zarr_kwargs, chunks=None)
 
         regridded = (
-                paths
+                self.pipeline
                 | xbeam.DatasetToChunks(source_ds, self.zarr_input_chunks)
                 | 'Regrid' >> beam.MapTuple(lambda k, ds: (k, self.regrid_dataset(ds)))
         )

--- a/weather_mv/loader_pipeline/regrid_test.py
+++ b/weather_mv/loader_pipeline/regrid_test.py
@@ -33,7 +33,7 @@ except (ModuleNotFoundError, ImportError, FileNotFoundError):
 
 def make_skin_temperature_dataset() -> xr.Dataset:
     ds = xr.DataArray(
-        np.zeros((4, 5, 6)) + 300.,
+        np.full((4, 5, 6), 300.),
         coords=[
             np.arange(0, 4),
             np.linspace(90., -90., 5),

--- a/weather_mv/loader_pipeline/regrid_test.py
+++ b/weather_mv/loader_pipeline/regrid_test.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import dataclasses
+import glob
 import os.path
 import tempfile
 import unittest
-import glob
 
-import apache_beam as beam
-from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that, equal_to
 import numpy as np
 import xarray as xr
+from apache_beam.testing.test_pipeline import TestPipeline
 from cfgrib.xarray_to_grib import to_grib
 
 from .regrid import Regrid

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -42,9 +42,10 @@ logger.setLevel(logging.INFO)
 
 @dataclasses.dataclass
 class ToDataSink(abc.ABC, beam.PTransform):
+    first_uri: str
     dry_run: bool
     zarr: bool
-    zarr_chunks: t.Dict
+    zarr_kwargs: t.Dict
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -43,6 +43,8 @@ logger.setLevel(logging.INFO)
 @dataclasses.dataclass
 class ToDataSink(abc.ABC, beam.PTransform):
     dry_run: bool
+    zarr: bool
+    zarr_chunks: t.Dict
 
     @classmethod
     def from_kwargs(cls, **kwargs):

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -58,6 +58,7 @@ base_requirements = [
     "earthengine-api>=0.1.263",
     "pyproj",  # requires separate binary installation!
     "gdal",  # requires separate binary installation!
+    "xarray-beam==0.3.1",
 ]
 
 

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -59,6 +59,7 @@ base_requirements = [
     "pyproj",  # requires separate binary installation!
     "gdal",  # requires separate binary installation!
     "xarray-beam==0.3.1",
+    "gcsfs==2022.11.0",
 ]
 
 

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -106,8 +106,7 @@ CUSTOM_COMMANDS = [
     cmd.split() for cmd in [
         'apt-get update',
         'apt-get --assume-yes install libeccodes-dev',
-        'conda install gdal -c conda-forge -y',
-        'conda install metview-batch -c conda-forge -y',
+        'conda install gdal=3.5.1 metview-batch=5.17.0 pyproj=3.4.0 -c conda-forge -y',
     ]
 ]
 
@@ -133,8 +132,7 @@ class CustomCommands(Command):
         stdout_data, _ = p.communicate()
         print('Command output: %s' % stdout_data)
         if p.returncode != 0:
-            raise print(
-                'Command %s failed: exit code: %s' % (command_list, p.returncode))
+            raise RuntimeError('Command %s failed: exit code: %s\n%s' % (command_list, p.returncode, stdout_data))
 
     def run(self):
         for command in CUSTOM_COMMANDS:


### PR DESCRIPTION
This change allows us to regrid Zarrs with MetView.

This PR will aid in accomplishing Phase 2 of https://github.com/google-research/ARCO-ERA5. There are three ways this routine could be used. First, we can create a version of our datasets that has been regridded to lat/lng with no other interpolation applied. Second, we can subclass the `Regrid` pipeline and override `apply_metview` to add any other fieldset operations we want to the chunks. This latter option allows us to regrid and interpolate data in one pass. Last, I offer a way to use process XArray datasets as MetView fieldsets via a PTransform. I also provide a PTransform for regridding with MetView.

CC: @wundersooner