### PR TITLE
weather_dl tests pass locally w/o a CDS config in home folder.

### DIFF
--- a/configs/era5_example_config.cfg
+++ b/configs/era5_example_config.cfg
@@ -20,6 +20,9 @@ partition_keys=
     month
     day
     pressure_level
+api_url=https://cds.climate.copernicus.eu/api/v2
+# a fake key for tests
+api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]
 product_type=reanalysis
 format=netcdf

--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -35,7 +35,10 @@ CONFIG = {
                                       '-pressure-{pressure_level}.nc',
                        'partition_keys': ['year', 'month', 'day', 'pressure_level'],
                        'force_download': False,
-                       'user_id': getpass.getuser()},
+                       'user_id': getpass.getuser(),
+                       'api_url': 'https://cds.climate.copernicus.eu/api/v2',
+                       'api_key': '12345:1234567-ab12-34cd-9876-4o4fake90909',  # fake key for testing.
+                       },
         'selection': {'product_type': 'reanalysis',
                       'format': 'netcdf',
                       'variable': ['divergence', 'fraction_of_cloud_cover', 'geopotential'],


### PR DESCRIPTION
Updated the pipeline tests to use a fake key, so users can run them without setting up a CDS license.