### PR TITLE
Fixed potential memory leak during splitting.

### DIFF
--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -115,7 +115,8 @@ class GribSplitter(FileSplitter):
     @contextmanager
     def _open_grib_locally(self) -> t.Iterator[t.Iterator[pygrib.gribmessage]]:
         with self._copy_to_local_file() as local_file:
-            yield pygrib.open(local_file.name)
+            with pygrib.open(local_file.name) as gb:
+                yield gb
 
 
 class NetCdfSplitter(FileSplitter):

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -93,22 +93,23 @@ class GribSplitter(FileSplitter):
             return
 
         with self._open_grib_locally() as grbs:
-            for grb in grbs:
-                splits = dict()
-                for dim in self.output_info.split_dims():
-                    try:
-                        splits[dim] = getattr(grb, dim)
-                    except RuntimeError:
-                        self.logger.error(
-                            'Variable not found in grib: %s', dim)
-                key = self.output_info.formatted_output_path(splits)
-                if key not in outputs:
-                    outputs[key] = FileSystems.create(key)
-                outputs[key].write(grb.tostring())
-                outputs[key].flush()
-
-            for out in outputs.values():
-                out.close()
+            try:
+                for grb in grbs:
+                    splits = dict()
+                    for dim in self.output_info.split_dims():
+                        try:
+                            splits[dim] = getattr(grb, dim)
+                        except RuntimeError:
+                            self.logger.error(
+                                'Variable not found in grib: %s', dim)
+                    key = self.output_info.formatted_output_path(splits)
+                    if key not in outputs:
+                        outputs[key] = FileSystems.create(key)
+                    outputs[key].write(grb.tostring())
+                    outputs[key].flush()
+            finally:
+                for out in outputs.values():
+                    out.close()
             self.logger.info('split %s into %d files',
                              self.input_path, len(outputs))
 

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -166,7 +166,9 @@ class NetCdfSplitter(FileSplitter):
     @contextmanager
     def _open_dataset_locally(self) -> t.Iterator[xr.Dataset]:
         with self._copy_to_local_file() as local_file:
-            yield xr.open_dataset(local_file.name, engine='netcdf4')
+            ds = xr.open_dataset(local_file.name, engine='netcdf4')
+            yield ds
+            ds.close()
 
     def _write_dataset(self, dataset: xr.Dataset, split_dims: t.List[str]) -> None:
         with FileSystems().create(self._get_output_for_dataset(dataset, split_dims)) as dest_file:

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -117,35 +117,31 @@ def run(argv: t.List[str], save_main_session: bool = True):
 
     pipeline_options = PipelineOptions(pipeline_args)
     pipeline_options.view_as(SetupOptions).save_main_session = save_main_session
-    input_pattern = known_args.input_pattern
-    input_base_dir = _get_base_input_directory(input_pattern)
-    output_template = known_args.output_template
-    output_dir = known_args.output_dir
-    formatting = known_args.formatting
+    input_base_dir = _get_base_input_directory(known_args.input_pattern)
 
-    if not output_template and not output_dir:
+    if not known_args.output_template and not known_args.output_dir:
         raise ValueError('No output specified')
-    dry_run = known_args.dry_run
 
-    logger.debug('input_pattern: %s', input_pattern)
+    logger.debug('input_pattern: %s', known_args.input_pattern)
     logger.debug('input_base_dir: %s', input_base_dir)
-    if output_template:
-        logger.debug('output_template: %s', output_template)
-    if output_dir:
-        logger.debug('output_dir: %s', output_dir)
+    if known_args.output_template:
+        logger.debug('output_template: %s', known_args.output_template)
+    if known_args.output_dir:
+        logger.debug('output_dir: %s', known_args.output_dir)
     logger.debug('dry_run: %s', known_args.dry_run)
+
     with beam.Pipeline(options=pipeline_options) as p:
         (
             p
-            | 'MatchFiles' >> MatchFiles(input_pattern)
+            | 'MatchFiles' >> MatchFiles(known_args.input_pattern)
             | 'ReadMatches' >> ReadMatches()
             | 'Shuffle' >> beam.Reshuffle()
             | 'GetPath' >> beam.Map(lambda x: x.metadata.path)
             | 'SplitFiles' >> beam.Map(split_file,
                                        input_base_dir,
-                                       output_template,
-                                       output_dir,
-                                       formatting,
-                                       dry_run,
+                                       known_args.output_template,
+                                       known_args.output_dir,
+                                       known_args.formatting,
+                                       known_args.dry_run,
                                        known_args.force)
         )


### PR DESCRIPTION
When we open a grib locally, we currently do not use a context manager to open it. This means that `close()` is never called on the open grib data, which would thus leak memory.

In addition to this fix, I've refactored a bit of pipeline code to use less variables.