### PR TITLE
Split NetCDF files are always written as NETCDF4 (HDF5 support).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ test_requirements = [
     "xarray-beam",
     "absl-py",
     "metview",
+    "h5py",
 ]
 
 all_test_requirements = beam_gcp_requirements + weather_dl_requirements + \

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import os
-import pygrib
 import shutil
 import unittest
-import xarray as xr
 from collections import defaultdict
+
+import h5py
+import numpy as np
+import pygrib
+import xarray as xr
 
 import weather_sp
 from .file_name_utils import OutFileInfo
@@ -253,6 +255,24 @@ class NetCdfSplitterTest(unittest.TestCase):
         splitter.split_data()
         self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
         self.assertFalse(splitter.should_skip())
+
+    def test_split_data__is_netcdf4(self):
+        input_path = f'{self._data_dir}/era5_sample.nc'
+        self.assertFalse(h5py.is_hdf5(input_path))
+        output_base = f'{self._data_dir}/split_files/era5_sample'
+        splitter = NetCdfSplitter(
+            input_path,
+            OutFileInfo(output_base,
+                        formatting='_{time}_{variable}',
+                        ending='.nc',
+                        template_folders=[]))
+
+        splitter.split_data()
+        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
+        for time in ['2015-01-15T00:00', '2015-01-15T06:00', '2015-01-15T12:00', '2015-01-15T18:00']:
+            for sn in ['d', 'cc', 'z']:
+                split_file = f'{self._data_dir}/split_files/era5_sample_{time}_{sn}.nc'
+                self.assertTrue(h5py.is_hdf5(split_file))
 
 
 class DrySplitterTest(unittest.TestCase):


### PR DESCRIPTION
Here, we slightly change how NetCDF files are written so that we can use a better engine (netcdf4 instead of scipy). This changes lets us write HDF5 compliant NetCDF files (v4 of the spec), which will enable us to read the split files much faster (via buffered readers + without copying the data locally first).

This PR does change memory / disk use during NetCDF splitting: Now, splitting first writes NetCDF files to disk before uploading to the cloud. The impact is that users may have to allocate more disk space to perform splitting.