### PR TITLE
GribSplitterV2: Splitting using `grib_copy`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       run: python -m metview selfcheck
     - name: Run unit tests
       shell: bash -l {0}
-      run: pytest
+      run: pytest --memray
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ test_requirements = [
     "xarray-beam",
     "absl-py",
     "metview",
+    "memray",
+    "pytest-memray",
     "h5py",
 ]
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -61,13 +61,13 @@ weather-sp --input-pattern 'gs://test-tmp/era5/2015/**' \
            --job_name $JOB_NAME
 ```
 
-Using ecCodes-powered grib splitting on Dataflow:
+Using ecCodes-powered grib splitting on Dataflow (this is often more robust, especially when splitting multiple 
+dimensions at once):
 
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --output-dir 'gs://test-tmp/era5/splits' \
            --formatting '.{typeOfLevel}' \
-           --use-version v2 \
            --runner DataflowRunner \
            --project $PROJECT \
            --temp_location gs://$BUCKET/tmp  \

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -12,7 +12,8 @@ Splits NetCDF and Grib files into several files by variable or other dimension. 
 ## Usage
 
 ```
-usage: weather-sp [-h] -i INPUT_PATTERN (--output-template OUTPUT_TEMPLATE | --output-dir OUTPUT_DIR) [--formatting FORMATTING] [-d] [-f]
+usage: weather-sp [-h] -i INPUT_PATTERN (--output-template OUTPUT_TEMPLATE | --output-dir OUTPUT_DIR)
+                  [--formatting FORMATTING] [-d] [-f] [--use-version USE_VERSION]
 ```
 
 _Common options_:
@@ -26,6 +27,8 @@ _Common options_:
    using Python formatting, see [Output section](#output) below.
 * `-f, --force`: Force re-splitting of the pipeline. Turns of skipping of already split data.
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
+* `--use-version`: Choose splitting implementation version (which depends on the data type)
+  Default: v1.
 
 Invoke with `-h` or `--help` to see the full range of options.
 
@@ -33,7 +36,7 @@ _Usage examples_:
 
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
-           --output-dir 'gs://test-tmp/era5/splits'
+           --output-dir 'gs://test-tmp/era5/splits' \
            --formatting '.{typeOfLevel}'
 ```
 
@@ -42,8 +45,17 @@ Preview splits with a dry run:
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --output-dir 'gs://test-tmp/era5/splits' \
-           --formatting '.{typeOfLevel}'
+           --formatting '.{typeOfLevel}' \
            --dry-run
+```
+
+Use a different version of Grib Splitting:
+
+```bash
+weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
+           --output-dir 'gs://test-tmp/era5/splits' \
+           --formatting '.{typeOfLevel}' \
+           --use-version v2
 ```
 
 Using DataflowRunner

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -73,7 +73,7 @@ weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --sdk_container_image="gcr.io/$PROJECT/$REPO:latest"  \
            --job_name $JOB_NAME
 ```
-_Consult [this documentation](../docs/Runtime-Container.md) for steps on how to create an sufficient image._
+_Consult [this documentation](../docs/Runtime-Container.md) for steps on how to create a sufficient image._
 _See the `weather-mv` documentation for more information about the container image._
 
 For a full list of how to configure the Dataflow pipeline, please review

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -49,26 +49,33 @@ weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --dry-run
 ```
 
-Use a different version of Grib Splitting:
-
-```bash
-weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
-           --output-dir 'gs://test-tmp/era5/splits' \
-           --formatting '.{typeOfLevel}' \
-           --use-version v2
-```
-
 Using DataflowRunner
 
 ```bash
 weather-sp --input-pattern 'gs://test-tmp/era5/2015/**' \
            --output-dir 'gs://test-tmp/era5/splits'
-           --formatting '.{typeOfLevel}'
+           --formatting '.{typeOfLevel}' \
            --runner DataflowRunner \
            --project $PROJECT \
            --temp_location gs://$BUCKET/tmp  \
            --job_name $JOB_NAME
 ```
+
+Using ecCodes-powered grib splitting on Dataflow:
+
+```bash
+weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
+           --output-dir 'gs://test-tmp/era5/splits' \
+           --formatting '.{typeOfLevel}' \
+           --use-version v2 \
+           --runner DataflowRunner \
+           --project $PROJECT \
+           --temp_location gs://$BUCKET/tmp  \
+           --experiment=use_runner_v2 \
+           --sdk_container_image="gcr.io/$PROJECT/$REPO:latest"  \
+           --job_name $JOB_NAME
+```
+_See the `weather-mv` documentation for more information about the container image._
 
 For a full list of how to configure the Dataflow pipeline, please review
 [this table](https://cloud.google.com/dataflow/docs/reference/pipeline-options).

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -27,8 +27,6 @@ _Common options_:
    using Python formatting, see [Output section](#output) below.
 * `-f, --force`: Force re-splitting of the pipeline. Turns of skipping of already split data.
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
-* `--use-version`: Choose splitting implementation version (which depends on the data type)
-  Default: v1.
 
 Invoke with `-h` or `--help` to see the full range of options.
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -75,6 +75,7 @@ weather-sp --input-pattern 'gs://test-tmp/era5/2017/**' \
            --sdk_container_image="gcr.io/$PROJECT/$REPO:latest"  \
            --job_name $JOB_NAME
 ```
+_Consult [this documentation](../docs/Runtime-Container.md) for steps on how to create an sufficient image._
 _See the `weather-mv` documentation for more information about the container image._
 
 For a full list of how to configure the Dataflow pipeline, please review

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -13,7 +13,7 @@ Splits NetCDF and Grib files into several files by variable or other dimension. 
 
 ```
 usage: weather-sp [-h] -i INPUT_PATTERN (--output-template OUTPUT_TEMPLATE | --output-dir OUTPUT_DIR)
-                  [--formatting FORMATTING] [-d] [-f] [--use-version USE_VERSION]
+                  [--formatting FORMATTING] [-d] [-f]
 ```
 
 _Common options_:

--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -33,6 +33,7 @@ beam_gcp_requirements = [
 
 base_requirements = [
     "pygrib",
+    "eccodes",
     "numpy>=1.20.3",
     "xarray",
     "scipy",

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -260,7 +260,7 @@ class DrySplitter(FileSplitter):
         return {name: name for name in self.output_info.split_dims()}
 
 
-def get_splitter(file_path: str, output_info: OutFileInfo, dry_run: bool, use_version: str,
+def get_splitter(file_path: str, output_info: OutFileInfo, dry_run: bool, use_version: str = 'v1',
                  force_split: bool = False) -> FileSplitter:
     if dry_run:
         return DrySplitter(file_path, output_info)

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -260,7 +260,8 @@ class DrySplitter(FileSplitter):
         return {name: name for name in self.output_info.split_dims()}
 
 
-def get_splitter(file_path: str, output_info: OutFileInfo, dry_run: bool, force_split: bool = False) -> FileSplitter:
+def get_splitter(file_path: str, output_info: OutFileInfo, dry_run: bool, use_version: str,
+                 force_split: bool = False) -> FileSplitter:
     if dry_run:
         return DrySplitter(file_path, output_info)
 
@@ -269,7 +270,13 @@ def get_splitter(file_path: str, output_info: OutFileInfo, dry_run: bool, force_
 
     if b'GRIB' in header:
         metrics.Metrics.counter('get_splitter', 'grib').inc()
-        return GribSplitterV2(file_path, output_info, force_split)
+
+        if '1' in use_version:
+            return GribSplitter(file_path, output_info, force_split)
+        elif '2' in use_version:
+            return GribSplitterV2(file_path, output_info, force_split)
+        else:
+            raise ValueError(f'version {use_version} is not recognized!')
 
     # See the NetCDF Spec docs:
     # https://docs.unidata.ucar.edu/netcdf-c/current/faq.html#How-can-I-tell-which-format-a-netCDF-file-uses

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import abc
-import os
 import itertools
 import logging
+import os
 import shutil
+import subprocess
 import tempfile
 import typing as t
 from contextlib import contextmanager
-import subprocess
 
 import apache_beam.metrics as metrics
 import numpy as np
@@ -138,14 +138,8 @@ class GribSplitter(FileSplitter):
 class GribSplitterV2(GribSplitter):
     """Splitter that makes use of `grib_copy` util for high performance splitting.
 
-
-    See https://confluence.ecmwf.int/display/ECC/grib_copy
+    See https://confluence.ecmwf.int/display/ECC/grib_copy.
     """
-
-    def __init__(self, input_path: str, output_info: OutFileInfo,
-                 force_split: bool = False, logging_level: int = logging.INFO):
-        super().__init__(input_path, output_info,
-                         force_split, logging_level)
 
     def split_data(self) -> None:
         if not self.output_info.split_dims():
@@ -167,8 +161,7 @@ class GribSplitterV2(GribSplitter):
                 if not cmd:
                     raise EnvironmentError('binary `grib_copy` is not available in the current environment!')
 
-                subprocess.run(f"{cmd} {local_file.name} {dest!r}",
-                               check=True, shell=True)
+                subprocess.run([cmd, local_file.name, dest], check=True)
 
                 for target in os.listdir(tmpdir):
                     with open(os.path.join(tmpdir, target), 'rb') as src_file:

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -163,7 +163,11 @@ class GribSplitterV2(GribSplitter):
             with tempfile.TemporaryDirectory() as tmpdir:
                 dest = os.path.join(tmpdir, output_template)
 
-                subprocess.run(f"{shutil.which('grib_copy')} {local_file.name} {dest!r}",
+                cmd = shutil.which('grib_copy')
+                if not cmd:
+                    raise EnvironmentError('binary `grib_copy` is not available in the current environment!')
+
+                subprocess.run(f"{cmd} {local_file.name} {dest!r}",
                                check=True, shell=True)
 
                 for target in os.listdir(tmpdir):

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -14,12 +14,11 @@
 
 import os
 import shutil
-import unittest
 from collections import defaultdict
 
-import h5py
 import numpy as np
 import pygrib
+import pytest
 import xarray as xr
 
 import weather_sp
@@ -31,40 +30,47 @@ from .file_splitters import NetCdfSplitter
 from .file_splitters import get_splitter
 
 
-class GetSplitterTest(unittest.TestCase):
+@pytest.fixture()
+def data_dir():
+    data_dir = f'{next(iter(weather_sp.__path__))}/test_data'
+    yield data_dir
+    split_dir = f'{data_dir}/split_files/'
+    if os.path.exists(split_dir):
+        shutil.rmtree(split_dir)
 
-    def setUp(self) -> None:
-        self._data_dir = f'{next(iter(weather_sp.__path__))}/test_data'
 
-    def test_get_splitter_grib(self):
-        splitter = get_splitter(f'{self._data_dir}/era5_sample.grib',
+class TestGetSplitter:
+
+    def test_get_splitter_grib(self, data_dir):
+        splitter = get_splitter(f'{data_dir}/era5_sample.grib',
                                 OutFileInfo(
                                     file_name_template='some_out_{split}',
                                     ending='.grib',
                                     formatting='',
                                     template_folders=[]),
                                 dry_run=False)
-        self.assertIsInstance(splitter, GribSplitter)
+        assert isinstance(splitter, GribSplitter)
 
-    def test_get_splitter_nc(self):
-        splitter = get_splitter(f'{self._data_dir}/era5_sample.nc',
+    def test_get_splitter_nc(self, data_dir):
+        splitter = get_splitter(f'{data_dir}/era5_sample.nc',
                                 OutFileInfo(
                                     file_name_template='some_out_{split}',
                                     ending='.nc',
                                     formatting='',
                                     template_folders=[]),
                                 dry_run=False)
-        self.assertIsInstance(splitter, NetCdfSplitter)
 
-    def test_get_splitter_undetermined_grib(self):
-        splitter = get_splitter(f'{self._data_dir}/era5_sample_grib',
+        assert isinstance(splitter, NetCdfSplitter)
+
+    def test_get_splitter_undetermined_grib(self, data_dir):
+        splitter = get_splitter(f'{data_dir}/era5_sample_grib',
                                 OutFileInfo(
                                     file_name_template='some_out_{split}',
                                     ending='',
                                     formatting='',
                                     template_folders=[]),
                                 dry_run=False)
-        self.assertIsInstance(splitter, GribSplitter)
+        assert isinstance(splitter, GribSplitter)
 
     def test_get_splitter_dryrun(self):
         splitter = get_splitter('some/file/path/data.grib',
@@ -74,19 +80,10 @@ class GetSplitterTest(unittest.TestCase):
                                     formatting='',
                                     template_folders=[]),
                                 dry_run=True)
-        self.assertIsInstance(splitter, DrySplitter)
+        assert isinstance(splitter, DrySplitter)
 
 
-class GribSplitterTest(unittest.TestCase):
-
-    def setUp(self):
-        self._data_dir = f'{next(iter(weather_sp.__path__))}/test_data'
-
-    def tearDown(self):
-        split_dir = f'{self._data_dir}/split_files/'
-        if os.path.exists(split_dir):
-            shutil.rmtree(split_dir)
-
+class TestGribSplitter:
     def test_get_output_file_path(self):
         splitter = GribSplitter(
             'path/to/input',
@@ -98,11 +95,11 @@ class GribSplitterTest(unittest.TestCase):
         )
         out = splitter.output_info.formatted_output_path(
             {'typeOfLevel': 'surface', 'shortName': 'cc'})
-        self.assertEqual(out, 'path/output/file.surface_cc.grib')
+        assert out == 'path/output/file.surface_cc.grib'
 
-    def test_split_data(self):
-        input_path = f'{self._data_dir}/era5_sample.grib'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_split_data(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.grib'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = GribSplitter(
             input_path,
             OutFileInfo(
@@ -112,7 +109,7 @@ class GribSplitterTest(unittest.TestCase):
                 template_folders=[])
         )
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
+        assert os.path.exists(f'{data_dir}/split_files/') is True
 
         short_names = ['z', 'r', 'cc', 'd']
         input_data = defaultdict(list)
@@ -123,7 +120,7 @@ class GribSplitterTest(unittest.TestCase):
             input_data[grb.shortName].append(grb.values)
 
         for sn in short_names:
-            split_file = f'{self._data_dir}/split_files/era5_sample_isobaricInhPa_{sn}.grib'
+            split_file = f'{data_dir}/split_files/era5_sample_isobaricInhPa_{sn}.grib'
             split_grbs = pygrib.open(split_file)
             for grb in split_grbs:
                 split_data[sn].append(grb.values)
@@ -131,26 +128,26 @@ class GribSplitterTest(unittest.TestCase):
         for sn in short_names:
             orig = np.array(input_data[sn])
             split = np.array(split_data[sn])
-            self.assertEqual(orig.shape, split.shape)
+            assert orig.shape == split.shape
             np.testing.assert_allclose(orig, split)
 
-    def test_skips_existing_split(self):
-        input_path = f'{self._data_dir}/era5_sample.grib'
+    def test_skips_existing_split(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.grib'
         splitter = GribSplitter(
             input_path,
-            OutFileInfo(f'{self._data_dir}/split_files/era5_sample',
+            OutFileInfo(f'{data_dir}/split_files/era5_sample',
                         formatting='_{typeOfLevel}_{shortName}',
                         ending='.grib',
                         template_folders=[])
         )
-        self.assertFalse(splitter.should_skip())
+        assert not splitter.should_skip()
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
-        self.assertTrue(splitter.should_skip())
+        assert os.path.exists(f'{data_dir}/split_files/')
+        assert splitter.should_skip()
 
-    def test_does_not_skip__if_forced(self):
-        input_path = f'{self._data_dir}/era5_sample.grib'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_does_not_skip__if_forced(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.grib'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = GribSplitter(
             input_path,
             OutFileInfo(
@@ -160,21 +157,27 @@ class GribSplitterTest(unittest.TestCase):
                 template_folders=[]),
             force_split=True
         )
-        self.assertFalse(splitter.should_skip())
+        assert not splitter.should_skip()
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
-        self.assertFalse(splitter.should_skip())
+        assert os.path.exists(f'{data_dir}/split_files/')
+        assert not splitter.should_skip()
+
+    @pytest.mark.limit_memory('2.5 MB')
+    def test_split__fits_memory_bounds(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.grib'
+        output_base = f'{data_dir}/split_files/era5_sample'
+        splitter = GribSplitter(
+            input_path,
+            OutFileInfo(
+                output_base,
+                formatting='_{typeOfLevel}_{shortName}',
+                ending='.grib',
+                template_folders=[])
+        )
+        splitter.split_data()
 
 
-class NetCdfSplitterTest(unittest.TestCase):
-
-    def setUp(self):
-        self._data_dir = f'{next(iter(weather_sp.__path__))}/test_data'
-
-    def tearDown(self):
-        split_dir = f'{self._data_dir}/split_files/'
-        if os.path.exists(split_dir):
-            shutil.rmtree(split_dir)
+class TestNetCdfSplitter:
 
     def test_get_output_file_path(self):
         splitter = NetCdfSplitter(
@@ -184,11 +187,11 @@ class NetCdfSplitterTest(unittest.TestCase):
                         formatting='',
                         template_folders=[]))
         out = splitter.output_info.formatted_output_path({'variable': 'cc'})
-        self.assertEqual(out, 'path/output/file_cc.nc')
+        assert out == 'path/output/file_cc.nc'
 
-    def test_split_data(self):
-        input_path = f'{self._data_dir}/era5_sample.nc'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_split_data(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(
             input_path,
             OutFileInfo(output_base,
@@ -197,53 +200,53 @@ class NetCdfSplitterTest(unittest.TestCase):
                         template_folders=[]))
 
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
+        assert os.path.exists(f'{data_dir}/split_files/')
         input_data = xr.open_dataset(input_path, engine='netcdf4')
         for time in ['2015-01-15T00:00', '2015-01-15T06:00', '2015-01-15T12:00', '2015-01-15T18:00']:
             expect = input_data.sel(time=time)
             for sn in ['d', 'cc', 'z']:
-                split_file = f'{self._data_dir}/split_files/era5_sample_{time}_{sn}.nc'
+                split_file = f'{data_dir}/split_files/era5_sample_{time}_{sn}.nc'
                 split_data = xr.open_dataset(split_file, engine='netcdf4')
                 xr.testing.assert_allclose(expect[sn], split_data[sn])
 
-    def test_split_data__not_in_dims_raises(self):
-        input_path = f'{self._data_dir}/era5_sample.nc'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_split_data__not_in_dims_raises(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
                                   OutFileInfo(output_base,
                                               formatting='_{level}',
                                               ending='.nc',
                                               template_folders=[]))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             splitter.split_data()
 
-    def test_split_data__unsupported_dim_raises(self):
-        input_path = f'{self._data_dir}/era5_sample.nc'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_split_data__unsupported_dim_raises(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
                                   OutFileInfo(output_base,
                                               formatting='_{longitude}',
                                               ending='.nc',
                                               template_folders=[]))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             splitter.split_data()
 
-    def test_skips_existing_split(self):
-        input_path = f'{self._data_dir}/era5_sample.nc'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_skips_existing_split(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
                                   OutFileInfo(output_base,
                                               formatting='_{variable}',
                                               ending='.nc',
                                               template_folders=[]))
-        self.assertFalse(splitter.should_skip())
+        assert not splitter.should_skip()
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
-        self.assertTrue(splitter.should_skip())
+        assert os.path.exists(f'{data_dir}/split_files/')
+        assert splitter.should_skip()
 
-    def test_does_not_skip__if_forced(self):
-        input_path = f'{self._data_dir}/era5_sample.nc'
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_does_not_skip__if_forced(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(input_path,
                                   OutFileInfo(
                                       output_base,
@@ -251,10 +254,23 @@ class NetCdfSplitterTest(unittest.TestCase):
                                       ending='.nc',
                                       template_folders=[]),
                                   force_split=True)
-        self.assertFalse(splitter.should_skip())
+        assert not splitter.should_skip()
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
-        self.assertFalse(splitter.should_skip())
+        assert os.path.exists(f'{data_dir}/split_files/')
+        assert not splitter.should_skip()
+
+    @pytest.mark.limit_memory('6 MB')
+    def test_split_data__fits_memory_bounds(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        output_base = f'{data_dir}/split_files/era5_sample'
+        splitter = NetCdfSplitter(
+            input_path,
+            OutFileInfo(output_base,
+                        formatting='_{time}_{variable}',
+                        ending='.nc',
+                        template_folders=[]))
+
+        splitter.split_data()
 
     def test_split_data__is_netcdf4(self):
         input_path = f'{self._data_dir}/era5_sample.nc'
@@ -275,7 +291,8 @@ class NetCdfSplitterTest(unittest.TestCase):
                 self.assertTrue(h5py.is_hdf5(split_file))
 
 
-class DrySplitterTest(unittest.TestCase):
+
+class TestDrySplitter:
 
     def test_path_with_output_pattern(self):
         input_path = 'a/b/c/d/file.nc'
@@ -284,10 +301,9 @@ class DrySplitterTest(unittest.TestCase):
             filename=input_path, out_pattern=out_pattern)
         splitter = DrySplitter(input_path, out_info)
         keys = splitter._get_keys()
-        self.assertEqual(keys, {'variable': 'variable'})
+        assert keys == {'variable': 'variable'}
         out_file = splitter.output_info.formatted_output_path(keys)
-        self.assertEqual(
-            out_file, 'gs://my_bucket/splits/c-d-file_old_data.variable.cd')
+        assert out_file == 'gs://my_bucket/splits/c-d-file_old_data.variable.cd'
 
     def test_path_with_output_pattern_no_formatting(self):
         # OutFileInfo using pattern but without any formatting marks.
@@ -296,9 +312,5 @@ class DrySplitterTest(unittest.TestCase):
                                            formatting='',
                                            ending='',
                                            template_folders=[]))
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             splitter.split_data()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -16,6 +16,7 @@ import os
 import shutil
 from collections import defaultdict
 
+import h5py
 import numpy as np
 import pygrib
 import pytest
@@ -277,10 +278,10 @@ class TestNetCdfSplitter:
 
         splitter.split_data()
 
-    def test_split_data__is_netcdf4(self):
-        input_path = f'{self._data_dir}/era5_sample.nc'
-        self.assertFalse(h5py.is_hdf5(input_path))
-        output_base = f'{self._data_dir}/split_files/era5_sample'
+    def test_split_data__is_netcdf4(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.nc'
+        assert not h5py.is_hdf5(input_path)
+        output_base = f'{data_dir}/split_files/era5_sample'
         splitter = NetCdfSplitter(
             input_path,
             OutFileInfo(output_base,
@@ -289,11 +290,11 @@ class TestNetCdfSplitter:
                         template_folders=[]))
 
         splitter.split_data()
-        self.assertTrue(os.path.exists(f'{self._data_dir}/split_files/'))
+        assert os.path.exists(f'{data_dir}/split_files/')
         for time in ['2015-01-15T00:00', '2015-01-15T06:00', '2015-01-15T12:00', '2015-01-15T18:00']:
             for sn in ['d', 'cc', 'z']:
-                split_file = f'{self._data_dir}/split_files/era5_sample_{time}_{sn}.nc'
-                self.assertTrue(h5py.is_hdf5(split_file))
+                split_file = f'{data_dir}/split_files/era5_sample_{time}_{sn}.nc'
+                assert h5py.is_hdf5(split_file)
 
 
 

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -168,7 +168,7 @@ class TestGribSplitter:
         assert os.path.exists(f'{data_dir}/split_files/')
         assert not splitter.should_skip()
 
-    @pytest.mark.limit_memory('2.5 MB')
+    @pytest.mark.limit_memory('30 MB')
     def test_split__fits_memory_bounds(self, data_dir, grib_splitter):
         input_path = f'{data_dir}/era5_sample.grib'
         output_base = f'{data_dir}/split_files/era5_sample'
@@ -265,7 +265,7 @@ class TestNetCdfSplitter:
         assert os.path.exists(f'{data_dir}/split_files/')
         assert not splitter.should_skip()
 
-    @pytest.mark.limit_memory('6 MB')
+    @pytest.mark.limit_memory('25 MB')
     def test_split_data__fits_memory_bounds(self, data_dir):
         input_path = f'{data_dir}/era5_sample.nc'
         output_base = f'{data_dir}/split_files/era5_sample'

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -297,7 +297,6 @@ class TestNetCdfSplitter:
                 assert h5py.is_hdf5(split_file)
 
 
-
 class TestDrySplitter:
 
     def test_path_with_output_pattern(self):

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -25,10 +25,13 @@ import xarray as xr
 import weather_sp
 from .file_name_utils import OutFileInfo
 from .file_name_utils import get_output_file_info
-from .file_splitters import DrySplitter, GribSplitterV2
-from .file_splitters import GribSplitter
-from .file_splitters import NetCdfSplitter
-from .file_splitters import get_splitter
+from .file_splitters import (
+    DrySplitter,
+    GribSplitter,
+    GribSplitterV2,
+    NetCdfSplitter,
+    get_splitter,
+)
 
 
 @pytest.fixture()

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -167,7 +167,7 @@ class TestGribSplitter:
         assert os.path.exists(f'{data_dir}/split_files/')
         assert not splitter.should_skip()
 
-    @pytest.mark.limit_memory('1 MB')
+    @pytest.mark.limit_memory('2.5 MB')
     def test_split__fits_memory_bounds(self, data_dir, grib_splitter):
         input_path = f'{data_dir}/era5_sample.grib'
         output_base = f'{data_dir}/split_files/era5_sample'

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -41,7 +41,7 @@ def split_file(input_file: str,
                output_dir: t.Optional[str],
                formatting: str,
                dry_run: bool,
-               use_version: str,
+               use_version: str = 'v1',
                force_split: bool = False):
     logger.info('Splitting file %s', input_file)
     metrics.Metrics.counter('pipeline', 'splitting file').inc()

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -113,8 +113,8 @@ def run(argv: t.List[str], save_main_session: bool = True):
                         help='Test the input file matching and the output file scheme without splitting.')
     parser.add_argument('-f', '--force', action='store_true', default=False,
                         help='Force re-splitting of the pipeline. Turns of skipping of already split data.')
-    parser.add_argument('--use-version', type=str, default='v1',
-                        help='Choose splitting implementation version (which depends on the data type). Default: v1.')
+    parser.add_argument('--use-version', type=str, default='v2',
+                        help='Choose splitting implementation version (which depends on the data type). Default: v2.')
     known_args, pipeline_args = parser.parse_known_args(argv[1:])
 
     configure_logger(2)  # 0 = error, 1 = warn, 2 = info, 3 = debug

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -41,6 +41,7 @@ def split_file(input_file: str,
                output_dir: t.Optional[str],
                formatting: str,
                dry_run: bool,
+               use_version: str,
                force_split: bool = False):
     logger.info('Splitting file %s', input_file)
     metrics.Metrics.counter('pipeline', 'splitting file').inc()
@@ -51,6 +52,7 @@ def split_file(input_file: str,
                                                  output_dir=output_dir,
                                                  formatting=formatting),
                             dry_run,
+                            use_version,
                             force_split)
     splitter.split_data()
 
@@ -111,6 +113,8 @@ def run(argv: t.List[str], save_main_session: bool = True):
                         help='Test the input file matching and the output file scheme without splitting.')
     parser.add_argument('-f', '--force', action='store_true', default=False,
                         help='Force re-splitting of the pipeline. Turns of skipping of already split data.')
+    parser.add_argument('--use-version', type=str, default='v1',
+                        help='Choose splitting implementation version (which depends on the data type). Default: v1.')
     known_args, pipeline_args = parser.parse_known_args(argv[1:])
 
     configure_logger(2)  # 0 = error, 1 = warn, 2 = info, 3 = debug
@@ -147,5 +151,6 @@ def run(argv: t.List[str], save_main_session: bool = True):
                                        output_dir,
                                        formatting,
                                        dry_run,
+                                       known_args.use_version,
                                        known_args.force)
         )

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -41,7 +41,6 @@ def split_file(input_file: str,
                output_dir: t.Optional[str],
                formatting: str,
                dry_run: bool,
-               use_version: str = 'v1',
                force_split: bool = False):
     logger.info('Splitting file %s', input_file)
     metrics.Metrics.counter('pipeline', 'splitting file').inc()
@@ -52,7 +51,6 @@ def split_file(input_file: str,
                                                  output_dir=output_dir,
                                                  formatting=formatting),
                             dry_run,
-                            use_version,
                             force_split)
     splitter.split_data()
 
@@ -113,8 +111,6 @@ def run(argv: t.List[str], save_main_session: bool = True):
                         help='Test the input file matching and the output file scheme without splitting.')
     parser.add_argument('-f', '--force', action='store_true', default=False,
                         help='Force re-splitting of the pipeline. Turns of skipping of already split data.')
-    parser.add_argument('--use-version', type=str, default='v2',
-                        help='Choose splitting implementation version (which depends on the data type). Default: v2.')
     known_args, pipeline_args = parser.parse_known_args(argv[1:])
 
     configure_logger(2)  # 0 = error, 1 = warn, 2 = info, 3 = debug
@@ -151,6 +147,5 @@ def run(argv: t.List[str], save_main_session: bool = True):
                                        output_dir,
                                        formatting,
                                        dry_run,
-                                       known_args.use_version,
                                        known_args.force)
         )


### PR DESCRIPTION
Adding support for splitting grib files by multiple dimensions at once. This PR does this by delegating the heavy lifting to ecCodes' `grib_copy` utility.

TODO
- [ ] Let's ensure that the `grib_copy` utility is installed on the runtime image (the recent Docker changes should fix this). 