### PR TITLE
XS Fix to clear memory + disk usage with Grib files.

### DIFF
--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -119,7 +119,7 @@ class GribSplitter(FileSplitter):
 
                     # Delete the grib message from memory – *and disk* – before moving on to the next
                     # grib message. See the pygrib sources for more info.
-                    # https://github.com/jswhit/pygrib/blob/aac60e86c665a94face3b9a52a8977735e3ac377/src/pygrib/_pygrib.pyx#L796
+                    # https://github.com/jswhit/pygrib/blob/v2.1.4rel/src/pygrib/_pygrib.pyx#L759
                     del grb
             finally:
                 for out in outputs.values():

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -116,6 +116,11 @@ class GribSplitter(FileSplitter):
                         outputs[key] = FileSystems.create(key)
                     outputs[key].write(grb.tostring())
                     outputs[key].flush()
+
+                    # Delete the grib message from memory – *and disk* – before moving on to the next
+                    # grib message. See the pygrib sources for more info.
+                    # https://github.com/jswhit/pygrib/blob/aac60e86c665a94face3b9a52a8977735e3ac377/src/pygrib/_pygrib.pyx#L796
+                    del grb
             finally:
                 for out in outputs.values():
                     out.close()


### PR DESCRIPTION
Worked with @uhager to try to fix resource issues with splitting grib files (memory and disk). Here, we attempt to deallocate grib messages just after we iterate over them during splitting.