### PR TITLE
weather_mv : support removed of making in-memory copy of dataset.

### DIFF
--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -56,7 +56,7 @@ Invoke with `-h` or `--help` to see the full range of options.
 usage: weather-mv bigquery [-h] -i URIS [--topic TOPIC] [--window_size WINDOW_SIZE] [--num_shards NUM_SHARDS] [-d]
                            -o OUTPUT_TABLE [-v variables [variables ...]] [-a area [area ...]]
                            [--import_time IMPORT_TIME] [--infer_schema]
-                           [--xarray_open_dataset_kwargs XARRAY_OPEN_DATASET_KWARGS] [--disable_in_memory_copy]
+                           [--xarray_open_dataset_kwargs XARRAY_OPEN_DATASET_KWARGS]
                            [--tif_metadata_for_datetime TIF_METADATA_FOR_DATETIME] [-s]
                            [--coordinate_chunk_size COORDINATE_CHUNK_SIZE]
 ```
@@ -74,7 +74,6 @@ _Command options_:
   (format: YYYY-MM-DD HH:MM:SS.usec+offset). Default: now in UTC.
 * `--infer_schema`: Download one file in the URI pattern and infer a schema from that file. Default: off
 * `--xarray_open_dataset_kwargs`: Keyword-args to pass into `xarray.open_dataset()` in the form of a JSON string.
-* `--disable_in_memory_copy`: Restrict in-memory copying of dataset. Default: False.
 * `--coordinate_chunk_size`: The size of the chunk of coordinates used for extracting vector data into BigQuery. Used to
   tune parallel uploads.
 * `--tif_metadata_for_datetime` : Metadata that contains tif file's timestamp. Applicable only for tif files.
@@ -114,16 +113,6 @@ weather-mv bq --uris "gs://your-bucket/*.nc" \
            --temp_location "gs://$BUCKET/tmp" \  # Needed for batch writes to BigQuery
            --direct_num_workers 2 \
            --dry-run
-```
-
-Restrict in-memory copying of dataset:
-
-```bash
-weather-mv bq --uris "gs://your-bucket/*.nc" \
-           --output_table $PROJECT.$DATASET_ID.$TABLE_ID \
-           --temp_location "gs://$BUCKET/tmp" \  # Needed for batch writes to BigQuery
-           --direct_num_workers 2 \
-           --disable_in_memory_copy
 ```
 
 Load COG's (.tif) files:
@@ -309,7 +298,7 @@ For a full list of how to configure the Dataflow pipeline, please review
 ```
 usage: weather-mv earthengine [-h] -i URIS --asset_location ASSET_LOCATION --ee_asset EE_ASSET
                            [--ee_asset_type ASSET_TYPE] [--disable_grib_schema_normalization] [--use_personal_account] [-s]
-                           [--xarray_open_dataset_kwargs XARRAY_OPEN_DATASET_KWARGS] [--disable_in_memory_copy]
+                           [--xarray_open_dataset_kwargs XARRAY_OPEN_DATASET_KWARGS]
                            [--service_account my-service-account@...gserviceaccount.com --private_key PRIVATE_KEY_LOCATION]
                            [--ee_qps EE_QPS] [--ee_latency EE_LATENCY] [--ee_max_concurrent EE_MAX_CONCURRENT]
 ```
@@ -332,7 +321,6 @@ _Command options_:
 * `--service_account`: Service account address when using a private key for earth engine authentication.
 * `--private_key`: To use a private key for earth engine authentication. Only used with the `service_account` flag.
 * `--xarray_open_dataset_kwargs`: Keyword-args to pass into `xarray.open_dataset()` in the form of a JSON string.
-* `--disable_in_memory_copy`: Restrict in-memory copying of dataset. Default: False.
 * `-s, --skip-region-validation` : Skip validation of regions for data migration. Default: off.
 * `--ee_qps`: Maximum queries per second allowed by EE for your project. Default: 10.
 * `--ee_latency`: The expected latency per requests, in seconds. Default: 0.5.
@@ -363,15 +351,6 @@ weather-mv ee --uris "gs://your-bucket/*.grib" \
            --asset_location "gs://$BUCKET/assets" \  # Needed to store assets generated from *.grib
            --ee_asset "projects/$PROJECT/assets/test_dir" \
            --dry-run
-```
-
-Restrict in-memory copying of dataset:
-
-```bash
-weather-mv ee --uris "gs://your-bucket/*.grib" \
-           --asset_location "gs://$BUCKET/assets" \  # Needed to store assets generated from *.grib
-           --ee_asset "projects/$PROJECT/assets/test_dir" \
-           --disable_in_memory_copy
 ```
 
 Authenticate earth engine using personal account:

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -16,8 +16,6 @@ import json
 import logging
 import typing as t
 import unittest
-from contextlib import contextmanager
-from time import perf_counter
 
 import geojson
 import numpy as np
@@ -379,15 +377,6 @@ class ExtractRowsTifSupportTest(ExtractRowsTestBase):
         self.assertRowsEqual(actual, expected)
 
 
-@contextmanager
-def timing(description: str) -> t.Iterator[None]:
-    logging.info(f"{description}: Starting profiler")
-    start = perf_counter()
-    yield
-    elapsed_time = perf_counter() - start
-    logging.info(f"{description}: Elapsed time: {elapsed_time:0.4f} seconds")
-
-
 class ExtractRowsGribSupportTest(ExtractRowsTestBase):
 
     def setUp(self) -> None:
@@ -599,23 +588,6 @@ class ExtractRowsGribSupportTest(ExtractRowsTestBase):
             'geo_point': geojson.dumps(geojson.Point((-180.0, 90.0))),
         }
         self.assertRowsEqual(actual, expected)
-
-    @_handle_missing_grib_be
-    def test_timing_profile(self):
-        self.test_data_path = f'{self.test_data_folder}/test_data_grib_single_timestep'
-        counter = 0
-        i = self.extract(self.test_data_path, disable_grib_schema_normalization=True)
-        # Read once to avoid counting dataset open times, etc.
-        _ = next(i)
-        with timing('Loop'):
-            for v in i:
-                # Don't do everything, 10K coordinates is enough for testing.
-                if counter >= 10000:
-                    break
-                if counter % 1000 == 0:
-                    logging.info(f'Processed {counter // 1000}k coordinates...')
-                counter += 1
-        logging.info(f'Finished {counter}')
 
 
 if __name__ == '__main__':

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -48,7 +48,6 @@ class TestCLI(unittest.TestCase):
             'window_size': 1.0,
             'xarray_open_dataset_kwargs': {},
             'coordinate_chunk_size': 10_000,
-            'disable_in_memory_copy': False,
             'disable_grib_schema_normalization': False,
             'tif_metadata_for_datetime': None,
         }

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -252,7 +252,6 @@ def open_local(uri: str) -> t.Iterator[str]:
 @contextlib.contextmanager
 def open_dataset(uri: str,
                  open_dataset_kwargs: t.Optional[t.Dict] = None,
-                 disable_in_memory_copy: bool = False,
                  disable_grib_schema_normalization: bool = False,
                  tif_metadata_for_datetime: t.Optional[str] = None) -> t.Iterator[xr.Dataset]:
     """Open the dataset at 'uri' and return a xarray.Dataset."""
@@ -267,9 +266,6 @@ def open_dataset(uri: str,
 
             if uri_extension == '.tif':
                 xr_dataset = _preprocess_tif(xr_dataset, local_path, tif_metadata_for_datetime)
-
-            if not disable_in_memory_copy:
-                xr_dataset = _make_grib_dataset_inmem(xr_dataset)
 
             # Extracting dtype, crs and transform from the dataset & storing them as attributes.
             with rasterio.open(local_path, 'r') as f:


### PR DESCRIPTION
As per the discussion with @alxmrs, we are removing support for in-memory copying of dataset -- as weather-mv code have been modified from the time this was introduced, and now the chunking logic & parallel execution of `extract_rows` step while ingesting in BQ served the same purpose.

Fixes #249 .
