### PR TITLE
Adding the mamba solver to our Dockerimage installation with Conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ FROM continuumio/miniconda3:latest
 # Update miniconda
 RUN conda update conda -y
 
+# Add the mamba solver for faster builds
+RUN conda install -n base conda-libmamba-solver
+RUN conda config --set solver libmamba
+
 # Create conda env using environment.yml
 ARG weather_tools_git_rev=main
 RUN git clone https://github.com/google/weather-tools.git /weather

--- a/weather_dl/setup.py
+++ b/weather_dl/setup.py
@@ -32,11 +32,11 @@ beam_gcp_requirements = [
 ]
 
 base_requirements = [
-    "cdsapi",
-    "ecmwf-api-client",
+    "cdsapi=0.5.1",
+    "ecmwf-api-client=1.6.3",
     "numpy>=1.19.1",
-    "pandas",
-    "xarray",
+    "pandas=1.5.1",
+    "xarray=2022.11.0",
     "requests>=2.24.0",
     "urllib3==1.26.5",
     "google-cloud-firestore==2.6.0",

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -42,19 +42,19 @@ beam_gcp_requirements = [
 
 base_requirements = [
     "dataclasses",
-    "numpy",
-    "pandas",
-    "xarray",
-    "cfgrib",
-    "netcdf4",
-    "geojson",
-    "simplejson",
-    "rioxarray",
-    "metview",
-    "rasterio",
+    "numpy=1.22.4",
+    "pandas=1.5.1",
+    "xarray=2022.11.0",
+    "cfgrib=0.9.10.2",
+    "netcdf4=1.6.1",
+    "geojson=2.5.0=py_0",
+    "simplejson=3.17.6",
+    "rioxarray=0.12.2",
+    "metview=1.13.1",
+    "rasterio= 1.3.1",
     "earthengine-api>=0.1.263",
-    "pyproj",  # requires separate binary installation!
-    "gdal",  # requires separate binary installation!
+    "pyproj=3.4.0",  # requires separate binary installation!
+    "gdal=3.5.1",  # requires separate binary installation!
 ]
 
 setup(

--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -32,11 +32,11 @@ beam_gcp_requirements = [
 ]
 
 base_requirements = [
-    "pygrib",
-    "eccodes",
+    "pygrib=2.1.4",
+    "eccodes=2.27.0",
     "numpy>=1.20.3",
-    "xarray",
-    "scipy",
+    "xarray=2022.11.0",
+    "scipy=1.9.3",
 ]
 
 setup(


### PR DESCRIPTION
This change does two things: 
- We pin all the `pip` dependency versions
- We add the `mamba` solver as the default solver to `conda` during our Docker installation process. 

Together (especially the latter change), we avoid an issue where cloud build fails due to a `conda` timeout during dependency resolution. 