### PR TITLE
Adding an ECMWF Public Datasets client.

### DIFF
--- a/configs/tigge_example_config.cfg
+++ b/configs/tigge_example_config.cfg
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[parameters]
+client=ecpublic
+target_path=gs://ecmwf-output-test/tigge/{}.gb
+partition_keys=
+    date
+[selection]
+class=ti
+dataset=tigge
+date=2020-01-01/to/2020-01-31
+expver=prod
+grid=0.25/0.25,
+levtype=sfc,
+number=1/to/50
+origin=ecmf
+param=167
+step=0/to/360/by/6
+time=00/12
+type=pf

--- a/configs/tigge_example_config.cfg
+++ b/configs/tigge_example_config.cfg
@@ -13,16 +13,16 @@
 # limitations under the License.
 [parameters]
 client=ecpublic
+dataset=tigge
 target_path=gs://ecmwf-output-test/tigge/{}.gb
 partition_keys=
     date
 [selection]
 class=ti
-dataset=tigge
 date=2020-01-01/to/2020-01-31
 expver=prod
-grid=0.25/0.25,
-levtype=sfc,
+grid=0.25/0.25
+levtype=sfc
 number=1/to/50
 origin=ecmf
 param=167

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -66,7 +66,7 @@ class Client(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def license_url(self, dataset: t.Optional[str] = None):
+    def license_url(self):
         """Specifies the License URL."""
         pass
 
@@ -109,7 +109,7 @@ class CdsClient(Client):
         self.c.retrieve(dataset, selection_, target)
 
     @property
-    def license_url(self, dataset=None):
+    def license_url(self):
         return 'https://cds.climate.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf'
 
     @classmethod
@@ -268,7 +268,7 @@ class MarsClient(Client):
             self.c.download(result, target=output)
 
     @property
-    def license_url(self, dataset: t.Optional[str] = None):
+    def license_url(self):
         return 'https://apps.ecmwf.int/datasets/licences/general/'
 
     @classmethod
@@ -307,10 +307,10 @@ class ECMWFPublicClient(Client):
         return 2
 
     @property
-    def license_url(self, dataset: t.Optional[str] = None):
-        if not dataset:
+    def license_url(self):
+        if not self.config.dataset:
             raise ValueError('must specify a dataset for this client!')
-        return f'https://apps.ecmwf.int/datasets/data/{dataset.lower()}/licence/'
+        return f'https://apps.ecmwf.int/datasets/data/{self.config.dataset.lower()}/licence/'
 
 
 class FakeClient(Client):

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -213,6 +213,8 @@ class SplitMARSRequest(api.APIRequest):
 
 
 class SplitRequestMixin:
+    c = None
+
     def fetch(self, req: t.Dict) -> t.Dict:
         return self.c.fetch(req)
 

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -322,8 +322,8 @@ class ECMWFPublicClient(Client):
 
     @classmethod
     def num_requests_per_key(cls, dataset: str) -> int:
-        # TODO(srasp): Look up request limits...
-        return 2
+        # Experimentally validated request limit.
+        return 5
 
     @property
     def license_url(self):

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -288,7 +288,7 @@ class MarsClient(Client):
 
 
 class ECMWFPublicClient(Client):
-    """A client for ECMWF's pubic datasets, like TIGGE."""
+    """A client for ECMWF's public datasets, like TIGGE."""
     def retrieve(self, dataset: str, selection: t.Dict, output: str) -> None:
         c = ECMWFDataServer(
             url=self.config.kwargs.get('api_url', os.environ.get("MARSAPI_URL")),

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -212,7 +212,15 @@ class SplitMARSRequest(api.APIRequest):
         self.connection.cleanup()
 
 
-class MARSECMWFServiceExtended(api.ECMWFService):
+class SplitRequestMixin:
+    def fetch(self, req: t.Dict) -> t.Dict:
+        return self.c.fetch(req)
+
+    def download(self, res: t.Dict, target: str) -> None:
+        self.c.download(res, target)
+
+
+class MARSECMWFServiceExtended(api.ECMWFService, SplitRequestMixin):
     """Extended MARS ECMFService class that separates fetch and download stage."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -226,14 +234,8 @@ class MARSECMWFServiceExtended(api.ECMWFService):
             quiet=self.quiet,
         )
 
-    def fetch(self, req: t.Dict) -> t.Dict:
-        return self.c.fetch(req)
 
-    def download(self, res: t.Dict, target: str) -> None:
-        self.c.download(res, target)
-
-
-class PublicECMWFServerExtended(MARSECMWFServiceExtended):
+class PublicECMWFServerExtended(api.ECMWFDataServer, SplitRequestMixin):
     def __init__(self, *args, dataset='', **kwargs):
         super().__init__(*args, **kwargs)
         self.c = SplitMARSRequest(

--- a/weather_dl/download_pipeline/clients.py
+++ b/weather_dl/download_pipeline/clients.py
@@ -27,7 +27,7 @@ from urllib.parse import urljoin
 
 import cdsapi
 import urllib3
-from ecmwfapi import ECMWFService, api, ECMWFDataServer
+from ecmwfapi import api
 
 from .config import Config, optimize_selection_partition
 from .util import retry_with_exponential_backoff
@@ -212,7 +212,7 @@ class SplitMARSRequest(api.APIRequest):
         self.connection.cleanup()
 
 
-class MARSECMWFServiceExtended(ECMWFService):
+class MARSECMWFServiceExtended(api.ECMWFService):
     """Extended MARS ECMFService class that separates fetch and download stage."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -210,9 +210,8 @@ def run(argv: t.List[str], save_main_session: bool = True) -> PipelineArgs:
     if num_requesters_per_key == -1:
         num_requesters_per_key = client.num_requests_per_key(config.dataset)
 
-    dataset = configs[0].dataset
     logger.warning(f'By using {client_name} datasets, '
-                   f'users agree to the terms and conditions specified in {client.license_url(dataset)!r}')
+                   f'users agree to the terms and conditions specified in {client.license_url!r}')
 
     return PipelineArgs(
         known_args, pipeline_options, configs, client_name, store, manifest, num_requesters_per_key

--- a/weather_dl/download_pipeline/pipeline.py
+++ b/weather_dl/download_pipeline/pipeline.py
@@ -210,8 +210,9 @@ def run(argv: t.List[str], save_main_session: bool = True) -> PipelineArgs:
     if num_requesters_per_key == -1:
         num_requesters_per_key = client.num_requests_per_key(config.dataset)
 
+    dataset = configs[0].dataset
     logger.warning(f'By using {client_name} datasets, '
-                   f'users agree to the terms and conditions specified in {client.license_url!r}')
+                   f'users agree to the terms and conditions specified in {client.license_url(dataset)!r}')
 
     return PipelineArgs(
         known_args, pipeline_options, configs, client_name, store, manifest, num_requesters_per_key


### PR DESCRIPTION
Currently, we can only download data from Copernicus and MARS. ECWMF also has a public dataset catalog. This PR introduces a new client to cover this data source. 