### PR TITLE
Project linter set to ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,12 +112,12 @@ For testing at development time, we make use of three tools:
    pytype weather_dl
    ```
 
-* `flake8` for linting:
+* `ruff` for linting:
    ```shell 
    # lint everything
-   flake8
+   ruff
    # lint a specific tool
-   flake8 weather_mv
+   ruff weather_mv
    ```
 
 * `pytest` for running tests:

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -19,7 +19,7 @@ dependencies:
   - xarray=2022.10.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
-  - flake8=5.0.4
+  - ruff=0.0.255
   - fsspec=2022.10.0
   - gdal=3.5.1
   - pyproj=3.4.0

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -19,7 +19,6 @@ dependencies:
   - xarray=2022.10.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
-  - ruff=0.0.260
   - fsspec=2022.10.0
   - gdal=3.5.1
   - pyproj=3.4.0
@@ -32,4 +31,5 @@ dependencies:
   - pygrib=2.1.4
   - pip:
     - earthengine-api==0.1.329
+    - ruff==0.0.260
     - .[test]

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -19,7 +19,7 @@ dependencies:
   - xarray=2022.10.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
-  - ruff=0.0.255
+  - ruff=0.0.260
   - fsspec=2022.10.0
   - gdal=3.5.1
   - pyproj=3.4.0

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -19,7 +19,7 @@ dependencies:
   - xarray=2022.10.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
-  - flake8=5.0.4
+  - ruff=0.0.255
   - fsspec=2022.10.0
   - gdal=3.5.1
   - pyproj=3.4.0

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -19,7 +19,6 @@ dependencies:
   - xarray=2022.10.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
-  - ruff=0.0.260
   - fsspec=2022.10.0
   - gdal=3.5.1
   - pyproj=3.4.0
@@ -32,4 +31,5 @@ dependencies:
   - pygrib=2.1.4
   - pip:
     - earthengine-api==0.1.329
+    - ruff==0.0.260
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -19,7 +19,7 @@ dependencies:
   - xarray=2022.10.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
-  - ruff=0.0.255
+  - ruff=0.0.260
   - fsspec=2022.10.0
   - gdal=3.5.1
   - pyproj=3.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[tool.ruff]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.10.
+target-version = "py310"
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 88
+line-length = 120
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ weather_sp_requirements = [
 
 test_requirements = [
     "pytype==2021.11.29",
-    "flake8",
+    "ruff",
     "pytest",
     "pytest-subtests",
     "netcdf4",


### PR DESCRIPTION
**Situation** 😊
- Original issue was #255 
- The current requirement is to set linter to ruff because of the stunning performance.

**Method I followed**

- I installed ruff version 0.0.255 using following command. 
```
pip install ruff
```
- Added a pyproject.toml to configure ruff and used the default configuration they have mentioned in the description here. 
[Link to ruff Github Repo](https://github.com/charliermarsh/ruff)
- Changed ci3.8.yml, ci3.9.yml, CONTRIBUTING.md and setup.py from flake8 to ruff.

**Evaluation**

- I run following commands seperately.
```
ruff check /workspace/weather-tools/weather_dl
```
```
ruff check /workspace/weather-tools/weather_mv
```
```
ruff check /workspace/weather-tools/weather_sp
```
- I got only E501 Line too long errors for all three. 
- So I changed a colon in line 52 /workspace/weather-tools/weather_dl/download_pipeline/clients.py file and checked about another error that can ruff can show us like this. 
<img width="1505" alt="Screenshot 2023-03-15 at 10 27 47" src="https://user-images.githubusercontent.com/47807830/225215480-cf8f813b-d12f-4bbf-8889-8aa0e8f5eb87.png">

**My final opinion**
- I think the linter ruff works fine for this weather tools project now as my knowledge. @alxmrs I hope you will check and lead me as you're doing from the beginning to do any changes with this PR. 
Thank you so much !! 😊