### PR TITLE
xarray version update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
+        channel-priority: strict
         environment-file: ci${{ matrix.python-version}}.yml
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         activate-environment: weather-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache@v2
       env:
         # Increase this value to reset cache if etc/example-environment.yml has not changed
-        CACHE_NUMBER: 1
+        CACHE_NUMBER: 0
       with:
         path: ~/conda_pkgs_dir
         key:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache@v2
       env:
         # Increase this value to reset cache if etc/example-environment.yml has not changed
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       with:
         path: ~/conda_pkgs_dir
         key:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        channel-priority: strict
         environment-file: ci${{ matrix.python-version}}.yml
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         activate-environment: weather-tools

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -30,6 +30,6 @@ dependencies:
   - pygrib=2.1.4
   - pip:
     - earthengine-api==0.1.329
-    - xarray=2023.1.0
+    - xarray==2023.1.0
     - ruff==0.0.260
     - .[test]

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -16,7 +16,6 @@ dependencies:
   - requests=2.28.1
   - netcdf4=1.6.1
   - rioxarray=0.12.2
-  - xarray=2023.1.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
   - fsspec=2022.10.0
@@ -31,5 +30,6 @@ dependencies:
   - pygrib=2.1.4
   - pip:
     - earthengine-api==0.1.329
+    - xarray=2023.1.0
     - ruff==0.0.260
     - .[test]

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -16,7 +16,7 @@ dependencies:
   - requests=2.28.1
   - netcdf4=1.6.1
   - rioxarray=0.12.2
-  - xarray=2022.10.0
+  - xarray=2023.1.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
   - fsspec=2022.10.0

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -30,6 +30,6 @@ dependencies:
   - pygrib=2.1.4
   - pip:
     - earthengine-api==0.1.329
-    - xarray=2023.1.0
+    - xarray==2023.1.0
     - ruff==0.0.260
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -16,7 +16,6 @@ dependencies:
   - requests=2.28.1
   - netcdf4=1.6.1
   - rioxarray=0.12.2
-  - xarray=2023.1.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
   - fsspec=2022.10.0
@@ -31,5 +30,6 @@ dependencies:
   - pygrib=2.1.4
   - pip:
     - earthengine-api==0.1.329
+    - xarray=2023.1.0
     - ruff==0.0.260
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -16,7 +16,7 @@ dependencies:
   - requests=2.28.1
   - netcdf4=1.6.1
   - rioxarray=0.12.2
-  - xarray=2022.10.0
+  - xarray=2023.1.0
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
   - fsspec=2022.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.8.13
   - apache-beam=2.40.0
   - xarray-beam=0.3.1
-  - xarray=2022.11.0
+  - xarray=2023.1.0
   - fsspec=2022.11.0
   - gcsfs=2022.11.0
   - rioxarray=0.12.2

--- a/weather_dl/setup.py
+++ b/weather_dl/setup.py
@@ -36,7 +36,7 @@ base_requirements = [
     "ecmwf-api-client==1.6.3",
     "numpy>=1.19.1",
     "pandas==1.5.1",
-    "xarray==2022.11.0",
+    "xarray==2023.1.0",
     "requests>=2.24.0",
     "urllib3==1.26.5",
     "google-cloud-firestore==2.6.0",

--- a/weather_mv/loader_pipeline/sinks_test.py
+++ b/weather_mv/loader_pipeline/sinks_test.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
 import datetime
 from functools import wraps
 import numpy as np
-import os
-import psutil
 import tempfile
+import tracemalloc
 import unittest
 import xarray as xr
 
@@ -43,12 +43,27 @@ def _handle_missing_grib_be(f):
     return decorated
 
 
-def generate_dataset() -> str:
+@contextlib.contextmanager
+def limit_memory(max_memory=30):
+    ''''Measure memory consumption of the function.
+        'memory limit' in MB
+    '''
+    try:
+        tracemalloc.start()
+        yield
+    finally:
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        assert peak / 1024 ** 2 <= max_memory, f"Memory usage {peak / 1024 ** 2} exceeded {max_memory} MB limit."
+
+
+@contextlib.contextmanager
+def write_netcdf():
     """Generates temporary netCDF file using xarray."""
     lat_dim = 3210
     lon_dim = 3440
-    lat = [0] * lat_dim
-    lon = [0] * lon_dim
+    lat = np.linspace(-90, 90, lat_dim)
+    lon = np.linspace(-180, 180, lon_dim)
     data_arr = np.random.uniform(low=0, high=0.1, size=(5, lat_dim, lon_dim))
 
     ds = xr.Dataset(
@@ -57,9 +72,9 @@ def generate_dataset() -> str:
             "lat": lat,
             "lon": lon,
         })
-    with tempfile.NamedTemporaryFile(delete=False) as fp:
+    with tempfile.NamedTemporaryFile() as fp:
         ds.to_netcdf(fp.name)
-        return fp.name
+        yield fp.name
 
 
 class OpenDatasetTest(TestDataBase):
@@ -92,13 +107,10 @@ class OpenDatasetTest(TestDataBase):
             self.assertDictContainsSubset({'is_normalized': False}, ds.attrs)
 
     def test_open_dataset__fits_memory_bounds(self):
-        file_name = generate_dataset()
-        memory_before = psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2
-        with open_dataset(file_name) as _:
-            pass
-        memory_after = psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2
-        os.unlink(file_name)
-        self.assertLessEqual((memory_after - memory_before), 30)
+        with write_netcdf() as test_netcdf_path:
+            with limit_memory(max_memory=30):
+                with open_dataset(test_netcdf_path) as _:
+                    pass
 
 
 class DatetimeTest(unittest.TestCase):

--- a/weather_mv/loader_pipeline/sinks_test.py
+++ b/weather_mv/loader_pipeline/sinks_test.py
@@ -42,28 +42,32 @@ def _handle_missing_grib_be(f):
 
     return decorated
 
+
 def generate_dataset() -> str:
     """Generates temporary netCDF file."""
     with tempfile.NamedTemporaryFile(delete=False) as fp:
         netcdf_file = nc.Dataset(fp.name, 'w', format='NETCDF4')
-        lat_dim = netcdf_file.createDimension('lat', 3210) # latitude axis
-        lon_dim = netcdf_file.createDimension('lon', 3440) # longitude axis
+        lat_dim = netcdf_file.createDimension('lat', 3210)  # latitude axis
+        lon_dim = netcdf_file.createDimension('lon', 3440)  # longitude axis
         time_dim = netcdf_file.createDimension('time', 5)
-        
-        lat = netcdf_file.createVariable('lat', np.float32, ('lat',))
-        lon = netcdf_file.createVariable('lon', np.float32, ('lon',))
 
-        var_1 = netcdf_file.createVariable('var_1',np.float64,('time','lat','lon'), zlib=True) 
-        
-        ntimes = len(time_dim); nlats = len(lat_dim); nlons = len(lon_dim)
+        lat = netcdf_file.createVariable('lat', np.float32, ('lat', ))
+        lon = netcdf_file.createVariable('lon', np.float32, ('lon', ))
+
+        var_1 = netcdf_file.createVariable('var_1', np.float64, ('time', 'lat', 'lon'), zlib=True)
+
+        ntimes = len(time_dim)
+        nlats = len(lat_dim)
+        nlons = len(lon_dim)
         lat[:] = 0
-        lon[:] = 0 
+        lon[:] = 0
 
-        data_arr = np.random.uniform(low=0,high=0.1,size=(ntimes,nlats,nlons))
-        var_1[:,:,:] = data_arr 
-       
-        netcdf_file.close(); 
+        data_arr = np.random.uniform(low=0, high=0.1, size=(ntimes, nlats, nlons))
+        var_1[:, :, :] = data_arr
+
+        netcdf_file.close()
         return fp.name
+
 
 class OpenDatasetTest(TestDataBase):
 
@@ -97,13 +101,13 @@ class OpenDatasetTest(TestDataBase):
     def test_open_dataset__fits_memory_bounds(self):
         file_name = generate_dataset()
         memory_before = psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2
-        with open_dataset(file_name) as ds:
+        with open_dataset(file_name) as _:
             pass
         memory_after = psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2
         os.unlink(file_name)
         self.assertLessEqual((memory_after - memory_before), 30)
 
-    
+
 class DatetimeTest(unittest.TestCase):
 
     def test_datetime_regex_string(self):

--- a/weather_mv/loader_pipeline/sinks_test.py
+++ b/weather_mv/loader_pipeline/sinks_test.py
@@ -50,13 +50,13 @@ def generate_dataset() -> str:
     lat = [0] * lat_dim
     lon = [0] * lon_dim
     data_arr = np.random.uniform(low=0, high=0.1, size=(5, lat_dim, lon_dim))
-    
+
     ds = xr.Dataset(
         {"var_1": (('time', 'lat', 'lon'), data_arr)},
         coords={
             "lat": lat,
             "lon": lon,
-        })   
+        })
     with tempfile.NamedTemporaryFile(delete=False) as fp:
         ds.to_netcdf(fp.name)
         return fp.name

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -62,7 +62,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.12',
+    version='0.2.13',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -44,7 +44,7 @@ base_requirements = [
     "dataclasses",
     "numpy==1.22.4",
     "pandas==1.5.1",
-    "xarray==2022.11.0",
+    "xarray==2023.1.0",
     "cfgrib==0.9.10.2",
     "netcdf4==1.6.1",
     "geojson==2.5.0",

--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -35,7 +35,7 @@ base_requirements = [
     "pygrib==2.1.4",
     "eccodes",
     "numpy>=1.20.3",
-    "xarray==2022.11.0",
+    "xarray==2023.1.0",
     "scipy==1.9.3",
 ]
 


### PR DESCRIPTION
Solution for the TODO of issue #291 `TODO: Find a better way for logging the dataset size.` is **just updating the version of xarray**.

The problem with the current version of xarray which we are using is it takes too much memory while calculating `dataset.nbytes`  (eg:  [`Line #408 weather-mv`](https://github.com/google/weather-tools/blob/main/weather_mv/loader_pipeline/sinks.py#L408)) and kills the process as well. 

To address the problem, I reported the issue on the official xarray GitHub page  [https://github.com/pydata/xarray/issues/7772](https://github.com/pydata/xarray/issues/7772) and they suggested to use the latest version of xarray. After testing, I found that xarray `v2023.1.0` worked well, and we no longer experienced any memory issues.

ps: This is the last `python 3.8` supported version of xarray.
