### PR TITLE
Fixed `gcloud alpha command` interactive prompt.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ ARG CONDA_ENV_NAME=weather-tools
 RUN echo "source activate ${CONDA_ENV_NAME}" >> ~/.bashrc
 ENV PATH /opt/conda/envs/${CONDA_ENV_NAME}/bin:$PATH
 
+# Install gcloud alpha
+RUN apt-get update -y
+RUN gcloud components install alpha --quiet
+
 # Copy files from official SDK image, including script/dependencies.
 COPY --from=beam_sdk /opt/apache/beam /opt/apache/beam
 

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -343,7 +343,7 @@ def copy(src: str, dst: str) -> None:
     errors: t.List[subprocess.CalledProcessError] = []
     for cmd in ['gcloud alpha storage cp', 'gsutil cp']:
         try:
-            subprocess.run(cmd.split() + [src, dst], check=True, capture_output=True)
+            subprocess.run(cmd.split() + [src, dst], check=True, capture_output=True, text=True, input="n/n")
             return
         except subprocess.CalledProcessError as e:
             errors.append(e)


### PR DESCRIPTION
Possible solution for this was adding the `gcloud components install alpha --quiet` to `weather_mv/setup.py`.
Ref-
https://github.com/google/weather-tools/blob/f2a255460ef23e960a7fc669ecdc27ff7d58c9c9/weather_mv/setup.py#L99-L104
But going forward we would be moving to conda instead of pip hence setup files would be removed eventually.

For now, the `subprocess.run()` command is passed with a negative input for any user prompt, this will not let the program hang at user input. Fixes #324.

Additionally, for the docker image, gcloud alpha commands are explicitly installed so that it's already in the environment when someone runs the tool on Dataflow providing the docker image.