### PR TITLE
fixed support for floating point numbers when specifying geographic region

### DIFF
--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -87,7 +87,7 @@ class ToBigQuery(ToDataSink):
     """
     output_table: str
     variables: t.List[str]
-    area: t.Tuple[int, int, int, int]
+    area: t.List[float]
     import_time: t.Optional[datetime.datetime]
     infer_schema: bool
     xarray_open_dataset_kwargs: t.Dict
@@ -104,7 +104,7 @@ class ToBigQuery(ToDataSink):
         subparser.add_argument('-v', '--variables', metavar='variables', type=str, nargs='+', default=list(),
                                help='Target variables (or coordinates) for the BigQuery schema. Default: will import '
                                     'all data variables as columns.')
-        subparser.add_argument('-a', '--area', metavar='area', type=int, nargs='+', default=list(),
+        subparser.add_argument('-a', '--area', metavar='area', type=float, nargs='+', default=list(),
                                help='Target area in [N, W, S, E]. Default: Will include all available area.')
         subparser.add_argument('--import_time', type=str, default=datetime.datetime.utcnow().isoformat(),
                                help=("When writing data to BigQuery, record that data import occurred at this "
@@ -270,7 +270,7 @@ def prepare_coordinates(
         uri: str, *,
         coordinate_chunk_size: int,
         variables: t.Optional[t.List[str]] = None,
-        area: t.Optional[t.List[int]] = None,
+        area: t.Optional[t.List[float]] = None,
         open_dataset_kwargs: t.Optional[t.Dict] = None,
         disable_grib_schema_normalization: bool = False,
         tif_metadata_for_datetime: t.Optional[str] = None) -> t.Iterator[t.Tuple[str, t.List[t.Dict]]]:

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -277,6 +277,22 @@ class ExtractRowsTest(ExtractRowsTestBase):
         }
         self.assertRowsEqual(actual, expected)
 
+    def test_extract_rows__specific_area_float_points(self):
+        actual = next(self.extract(self.test_data_path, area=[45.34, -103.45, 33.34, -92.87]))
+        expected = {
+            'd2m': 246.47116088867188,
+            'data_import_time': '1970-01-01T00:00:00+00:00',
+            'data_first_step': '2018-01-02T06:00:00+00:00',
+            'data_uri': self.test_data_path,
+            'latitude': 45.20000076293945,
+            'longitude': -103.4000015258789,
+            'time': '2018-01-02T06:00:00+00:00',
+            'u10': 3.94743275642395,
+            'v10': -0.19749987125396729,
+            'geo_point': geojson.dumps(geojson.Point((-103.400002, 45.200001))),
+        }
+        self.assertRowsEqual(actual, expected)
+
     def test_extract_rows__specify_import_time(self):
         now = datetime.datetime.utcnow().isoformat()
         actual = next(self.extract(self.test_data_path, import_time=now))


### PR DESCRIPTION
The issue  #183 was users were not able to pass floating point for ``-a, --area`` argument. It was throwing error `weather-mv bigquery: error: argument -a/--area: invalid int value: '49.34'.`  This error was because the type for argument was specified as `int.`

changing the type for argument `-a, --area` to `float`  Fixes #183 