### PR TITLE
Unit Tests for JSON Serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "UP"]
+select = ["E", "F"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
+select = ["E", "F", "UP"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -86,11 +86,11 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
     logger.debug('Serializing to JSON')
 
     # pd.isna() returns ndarray if input is not scalar therefore checking if not ndarray.
-    if type(value) != np.ndarray and (pd.isna(value) or value is None):
+    if (np.isscalar(value) and pd.isna(value)) or value is None:
         return None
     elif np.issubdtype(type(value), np.floating):
         return float(value)
-    elif type(value) == np.ndarray:
+    elif isinstance(value, np.ndarray):
         # Will return a scaler if array is of size 1, else will return a list.
         # Replace all NaNs, NaTs with None.
         return np.where(pd.isna(value), None, value).tolist()

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -85,13 +85,13 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
     # Note: The order of processing is significant.
     logger.debug('Serializing to JSON')
 
-    if pd.isna(value) or value is None:
+    if type(value) != np.ndarray and (pd.isna(value) or value is None):
         return None
     elif np.issubdtype(type(value), np.floating):
         return float(value)
     elif type(value) == np.ndarray:
         # Will return a scaler if array is of size 1, else will return a list.
-        return value.tolist()
+        return np.where(pd.isna(value), None, value).tolist()
     elif type(value) == datetime.datetime or type(value) == str or type(value) == np.datetime64:
         # Assume strings are ISO format timestamps...
         try:

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -85,12 +85,14 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
     # Note: The order of processing is significant.
     logger.debug('Serializing to JSON')
 
+    # pd.isna() returns ndarray is input is not scalar therefore checking if not ndarray.
     if type(value) != np.ndarray and (pd.isna(value) or value is None):
         return None
     elif np.issubdtype(type(value), np.floating):
         return float(value)
     elif type(value) == np.ndarray:
         # Will return a scaler if array is of size 1, else will return a list.
+        # Replace all NaNs, NaTs with None
         return np.where(pd.isna(value), None, value).tolist()
     elif type(value) == datetime.datetime or type(value) == str or type(value) == np.datetime64:
         # Assume strings are ISO format timestamps...

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -92,7 +92,7 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
         return float(value)
     elif type(value) == np.ndarray:
         # Will return a scaler if array is of size 1, else will return a list.
-        # Replace all NaNs, NaTs with None
+        # Replace all NaNs, NaTs with None.
         return np.where(pd.isna(value), None, value).tolist()
     elif type(value) == datetime.datetime or type(value) == str or type(value) == np.datetime64:
         # Assume strings are ISO format timestamps...

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -85,7 +85,7 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
     # Note: The order of processing is significant.
     logger.debug('Serializing to JSON')
 
-    # pd.isna() returns ndarray if input is not scalar therefore checking if not ndarray.
+    # pd.isna() returns ndarray if input is not scalar therefore checking if value is scalar.
     if (np.isscalar(value) and pd.isna(value)) or value is None:
         return None
     elif np.issubdtype(type(value), np.floating):

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -90,11 +90,14 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
         return None
     elif np.issubdtype(type(value), np.floating):
         return float(value)
+    elif isinstance(value, set):
+        value = list(value)
+        return np.where(pd.isna(value), None, value).tolist()
     elif isinstance(value, np.ndarray):
         # Will return a scaler if array is of size 1, else will return a list.
         # Replace all NaNs, NaTs with None.
         return np.where(pd.isna(value), None, value).tolist()
-    elif type(value) == datetime.datetime or type(value) == str or type(value) == np.datetime64:
+    elif isinstance(value, datetime.datetime) or isinstance(value, str) or isinstance(value, np.datetime64):
         # Assume strings are ISO format timestamps...
         try:
             value = datetime.datetime.fromisoformat(value)
@@ -115,7 +118,7 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
 
         # We assume here that naive timestamps are in UTC timezone.
         return value.replace(tzinfo=datetime.timezone.utc).isoformat()
-    elif type(value) == np.timedelta64:
+    elif isinstance(value, np.timedelta64):
         # Return time delta in seconds.
         return float(value / np.timedelta64(1, 's'))
     # This check must happen after processing np.timedelta64 and np.datetime64.

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -85,7 +85,7 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
     # Note: The order of processing is significant.
     logger.debug('Serializing to JSON')
 
-    # pd.isna() returns ndarray is input is not scalar therefore checking if not ndarray.
+    # pd.isna() returns ndarray if input is not scalar therefore checking if not ndarray.
     if type(value) != np.ndarray and (pd.isna(value) or value is None):
         return None
     elif np.issubdtype(type(value), np.floating):

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -190,7 +190,7 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
         actual = to_json_serializable_type(attrs)
 
         self.assertEqual(actual, expected)
-        self.assertEquals(type(actual), type(expected))
+        self.assertEqual(type(actual), type(expected))
 
     def test_to_json_serializable_type_npfloat(self):
         attrs = np.float32(1)
@@ -199,8 +199,8 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
 
         actual = to_json_serializable_type(attrs)
 
-        self.assertEquals(actual, expected)
-        self.assertEquals(type(actual), type(expected))
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
 
     def test_to_json_serializable_type_ndarray(self):
         attrs = np.arange(5)
@@ -209,8 +209,8 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
 
         actual = to_json_serializable_type(attrs)
 
-        self.assertEquals(actual, expected)
-        self.assertEquals(type(actual), type(expected))
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
 
     def test_to_json_serializable_type_datetime(self):
         input_date = '2000-01-01T00:00:00+00:00'
@@ -265,5 +265,5 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
 
         actual = to_json_serializable_type(attrs)
 
-        self.assertEquals(actual, expected)
-        self.assertEquals(type(actual), type(expected))
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -14,12 +14,14 @@
 import itertools
 import unittest
 from collections import Counter
+from datetime import datetime
 
 import xarray
 import xarray as xr
+import numpy as np
 
 from .sinks_test import TestDataBase
-from .util import get_coordinates, ichunked, make_attrs_ee_compatible
+from .util import get_coordinates, ichunked, make_attrs_ee_compatible, to_json_serializable_type
 
 
 class GetCoordinatesTest(TestDataBase):
@@ -179,4 +181,89 @@ class MakeAttrsEeCompatibleTests(TestDataBase):
 
 class ToJsonSerializableTypeTests(unittest.TestCase):
     # TODO(#106): Write tests...
-    pass
+    
+    def test_to_json_serializable_type_none(self):
+        attrs = None
+        
+        expected = None
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEqual(actual, expected)
+        self.assertEquals(type(actual), type(expected))
+
+    def test_to_json_serializable_type_npfloat(self):
+        attrs = np.float32(1)
+        
+        expected = float(1)
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(type(actual), type(expected))
+
+    def test_to_json_serializable_type_ndarray(self):
+        attrs = np.arange(5)
+
+        expected = [0, 1, 2, 3, 4]
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(type(actual), type(expected))
+    
+    def test_to_json_serializable_type_datetime(self):
+        input_date = '2000-01-01T00:00:00+00:00'
+
+        attrs = datetime.fromisoformat(input_date) 
+
+        expected = input_date
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+
+    def test_to_json_serializable_type_datetimestr(self):
+        input_date = '2000-01-01T00:00:00+00:00'
+
+        attrs = input_date
+
+        expected = input_date
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+
+    def test_to_json_serializable_type_npdatetime(self):
+        input_date = '2000-01-01T00:00:00+00:00'
+
+        attrs = np.datetime64(input_date)
+
+        expected = input_date
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+
+    def test_to_json_serializable_type_nptimedelta(self):
+        attrs = np.timedelta64(1, 'm') # timedelta of 1 minute.
+
+        expected = float(60) # seconds.
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+    
+    def test_to_json_serializable_type_npinteger(self):
+        attrs = np.int32(1)
+        
+        expected = int(1)
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(type(actual), type(expected))

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -180,7 +180,6 @@ class MakeAttrsEeCompatibleTests(TestDataBase):
 
 
 class ToJsonSerializableTypeTests(unittest.TestCase):
-    # TODO(#106): Write tests...
 
     def test_to_json_serializable_type_none(self):
         attrs = None

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -21,7 +21,12 @@ import xarray as xr
 import numpy as np
 
 from .sinks_test import TestDataBase
-from .util import get_coordinates, ichunked, make_attrs_ee_compatible, to_json_serializable_type
+from .util import (
+    get_coordinates, 
+    ichunked, 
+    make_attrs_ee_compatible, 
+    to_json_serializable_type,
+)
 
 
 class GetCoordinatesTest(TestDataBase):

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -215,6 +215,13 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
         self.assertEqual(self._convert(np.int64(-10_000)), -10_000)
         self.assertEqual(self._convert(np.uint16(25)), 25)
 
+    def test_to_json_serializable_type_set(self):
+        self.assertEqual(self._convert(set({})), [])
+        self.assertEqual(self._convert(set({1, 2, 3})), [1, 2, 3])
+        self.assertEqual(self._convert(set({1})), [1])
+        self.assertEqual(self._convert(set({None})), [None])
+        self.assertEqual(self._convert(set({float('NaN')})), [None])
+
     def test_to_json_serializable_type_ndarray(self):
         self.assertIsInstance(self._convert(np.array(list(range(10)))), list)
         self.assertEqual(self._convert(np.array(list(range(10)))), list(range(10)))

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -181,10 +181,10 @@ class MakeAttrsEeCompatibleTests(TestDataBase):
 
 class ToJsonSerializableTypeTests(unittest.TestCase):
     # TODO(#106): Write tests...
-    
+
     def test_to_json_serializable_type_none(self):
         attrs = None
-        
+
         expected = None
 
         actual = to_json_serializable_type(attrs)
@@ -194,7 +194,7 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
 
     def test_to_json_serializable_type_npfloat(self):
         attrs = np.float32(1)
-        
+
         expected = float(1)
 
         actual = to_json_serializable_type(attrs)
@@ -211,11 +211,11 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
 
         self.assertEquals(actual, expected)
         self.assertEquals(type(actual), type(expected))
-    
+
     def test_to_json_serializable_type_datetime(self):
         input_date = '2000-01-01T00:00:00+00:00'
 
-        attrs = datetime.fromisoformat(input_date) 
+        attrs = datetime.fromisoformat(input_date)
 
         expected = input_date
 
@@ -249,18 +249,18 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
         self.assertEqual(type(actual), type(expected))
 
     def test_to_json_serializable_type_nptimedelta(self):
-        attrs = np.timedelta64(1, 'm') # timedelta of 1 minute.
+        attrs = np.timedelta64(1, 'm')  # timedelta of 1 minute.
 
-        expected = float(60) # seconds.
+        expected = float(60)  # seconds.
 
         actual = to_json_serializable_type(attrs)
 
         self.assertEqual(actual, expected)
         self.assertEqual(type(actual), type(expected))
-    
+
     def test_to_json_serializable_type_npinteger(self):
         attrs = np.int32(1)
-        
+
         expected = int(1)
 
         actual = to_json_serializable_type(attrs)

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -22,9 +22,9 @@ import numpy as np
 
 from .sinks_test import TestDataBase
 from .util import (
-    get_coordinates, 
-    ichunked, 
-    make_attrs_ee_compatible, 
+    get_coordinates,
+    ichunked,
+    make_attrs_ee_compatible,
     to_json_serializable_type,
 )
 
@@ -210,6 +210,16 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
         attrs = np.arange(5)
 
         expected = [0, 1, 2, 3, 4]
+
+        actual = to_json_serializable_type(attrs)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+
+    def test_to_json_serializable_type_ndarray_sizeone(self):
+        attrs = np.arange(1)
+
+        expected = [0]
 
         actual = to_json_serializable_type(attrs)
 


### PR DESCRIPTION
Fixes #106. Unit tests for `to_json_serializable_type()` in `weather_mv/loader_pipeline/utils.py`. 

The current implementation of `to_json_serializable_type()`  throws error when a `ndarray` of size > 1 is passed.  Also, it did not handle arrays with NaNs and numbers mixed. 
Both of these issues are fixed in this PR.