### PR TITLE
added support for source data with multiple time dimensions

### DIFF
--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -333,6 +333,8 @@ _Command options_:
 * `--band_names_mapping`: A JSON file which contains the band names for the TIFF file.
 * `--initialization_time_regex`: A Regex string to get the initialization time from the filename.
 * `--forecast_time_regex`: A Regex string to get the forecast/end time from the filename.
+* `--tiff_config`: Configs to handle source data with more than two dimensions. It is a JSON string containing two keys as `dims`(array with dimensions) and `individual_assets`(boolean). `individual_assets` true will create a seperate tiff files otherwise by default tiff files will be created considering time and step dimension, rest all data will be stored as bands. 
+e.g {"dims":["isobaricInhPa"],"individual_assets":True} 
 
 Invoke with `ee -h` or `earthengine --help` to see the full range of options.
 

--- a/weather_mv/loader_pipeline/ee_test.py
+++ b/weather_mv/loader_pipeline/ee_test.py
@@ -65,15 +65,22 @@ class ConvertToAssetTests(TestDataBase):
     def setUp(self) -> None:
         super().setUp()
         self.tmpdir = tempfile.TemporaryDirectory()
-        self.convert_to_image_asset = ConvertToAsset(asset_location=self.tmpdir.name)
-        self.convert_to_table_asset = ConvertToAsset(asset_location=self.tmpdir.name, ee_asset_type='TABLE')
+        self.convert_to_image_asset = ConvertToAsset(
+            asset_location=self.tmpdir.name,
+            tiff_config={"dims": [], "individual_assets": False},
+        )
+        self.convert_to_table_asset = ConvertToAsset(
+            asset_location=self.tmpdir.name,
+            ee_asset_type='TABLE',
+            tiff_config={"dims": [], "individual_assets": False},
+        )
 
     def tearDown(self):
         self.tmpdir.cleanup()
 
     def test_convert_to_image_asset(self):
         data_path = f'{self.test_data_folder}/test_data_grib_single_timestep'
-        asset_path = os.path.join(self.tmpdir.name, 'test_data_grib_single_timestep.tiff')
+        asset_path = os.path.join(self.tmpdir.name, 'test_data_grib_single_timestep_20211018060000.tiff')
 
         next(self.convert_to_image_asset.process(data_path))
 
@@ -82,7 +89,10 @@ class ConvertToAssetTests(TestDataBase):
 
     def test_convert_to_image_asset__with_multiple_grib_edition(self):
         data_path = f'{self.test_data_folder}/test_data_grib_multiple_edition_single_timestep.bz2'
-        asset_path = os.path.join(self.tmpdir.name, 'test_data_grib_multiple_edition_single_timestep.tiff')
+        asset_path = os.path.join(
+            self.tmpdir.name,
+            'test_data_grib_multiple_edition_single_timestep_20211210120000_FH-8.tiff',
+        )
 
         next(self.convert_to_image_asset.process(data_path))
 
@@ -91,7 +101,7 @@ class ConvertToAssetTests(TestDataBase):
 
     def test_convert_to_table_asset(self):
         data_path = f'{self.test_data_folder}/test_data_grib_single_timestep'
-        asset_path = os.path.join(self.tmpdir.name, 'test_data_grib_single_timestep.csv')
+        asset_path = os.path.join(self.tmpdir.name, 'test_data_grib_single_timestep_20211018060000.csv')
 
         next(self.convert_to_table_asset.process(data_path))
 
@@ -100,7 +110,10 @@ class ConvertToAssetTests(TestDataBase):
 
     def test_convert_to_table_asset__with_multiple_grib_edition(self):
         data_path = f'{self.test_data_folder}/test_data_grib_multiple_edition_single_timestep.bz2'
-        asset_path = os.path.join(self.tmpdir.name, 'test_data_grib_multiple_edition_single_timestep.csv')
+        asset_path = os.path.join(
+            self.tmpdir.name,
+            'test_data_grib_multiple_edition_single_timestep_20211210120000_FH-8.csv',
+        )
 
         next(self.convert_to_table_asset.process(data_path))
 


### PR DESCRIPTION
resolves #305
solution is to either create multiple tiff files or store data as bands. So user can specify using `--tiff_config` which dimensions to consider while creating tiff files and whether to create separate tiff files or store as bands. tiff_config will look like this 
`{"dims":["isobaricInhPa"],"individual_assets":True} `
By default if time or step dimension is present in source data then it will create multiple tiff files for these dimensions.