### PR TITLE
Using rioxarray for opening .tiff files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
+        channels: conda-forge
         environment-file: ci${{ matrix.python-version}}.yml
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         activate-environment: weather-tools

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -15,7 +15,7 @@ dependencies:
   - eccodes=2.27.0
   - requests=2.28.1
   - netcdf4=1.6.1
-  - rioxarray=0.12.2
+  - rioxarray=0.13.4
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
   - fsspec=2022.10.0

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -15,7 +15,7 @@ dependencies:
   - eccodes=2.27.0
   - requests=2.28.1
   - netcdf4=1.6.1
-  - rioxarray=0.12.2
+  - rioxarray=0.13.4
   - xarray-beam=0.3.1
   - ecmwf-api-client=1.6.3
   - fsspec=2022.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - xarray=2023.1.0
   - fsspec=2022.11.0
   - gcsfs=2022.11.0
-  - rioxarray=0.12.2
+  - rioxarray=0.13.4
   - gdal=3.5.1
   - pyproj=3.4.0
   - cdsapi=0.5.1

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -146,15 +146,12 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
     This also retrieves datetime from tif's metadata and stores it into dataset.
     """
 
-    def replace_dataarray_names_with_long_names(ds):
-        new_ds = xr.Dataset()
-        new_ds.attrs = ds.attrs
+    def replace_dataarray_names_with_long_names(ds: xr.Dataset):
+        rename_dict = {}
         for var_name in ds.variables:
-            var = ds[var_name]
-            long_name = var.attrs.get('long_name', var_name)
-            new_ds[long_name] = var
-        new_ds.attrs = ds.attrs
-        return new_ds
+            rename_dict[var_name] = ds[var_name].attrs.get('long_name', var_name)
+        print(rename_dict)
+        return ds.rename(rename_dict)
 
     y, x = np.meshgrid(ds['y'], ds['x'])
     transformer = Transformer.from_crs(ds.spatial_ref.crs_wkt, TIF_TRANSFORM_CRS_TO, always_xy=True)

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -181,16 +181,15 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
         ds.attrs['start_time'] = start_time
         ds.attrs['end_time'] = end_time
 
-    with rasterio.open(filename) as f:
-        datetime_value_ms = None
-        try:
-            datetime_value_s = (int(end_time.timestamp()) if end_time is not None
-                                else int(f.tags()[tif_metadata_for_datetime]) / 1000.0)
-            ds = ds.assign_coords({'time': datetime.datetime.utcfromtimestamp(datetime_value_s)})
-        except KeyError:
+    datetime_value_ms = None
+    try:
+        datetime_value_s = (int(end_time.timestamp()) if end_time is not None
+                        else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0)
+        ds = ds.assign_coords({'time': datetime.datetime.utcfromtimestamp(datetime_value_s)})
+    except KeyError:
             raise RuntimeError(f"Invalid datetime metadata of tif: {tif_metadata_for_datetime}.")
-        except ValueError:
-            raise RuntimeError(f"Invalid datetime value in tif's metadata: {datetime_value_ms}.")
+    except ValueError:
+        raise RuntimeError(f"Invalid datetime value in tif's metadata: {datetime_value_ms}.")
 
     return ds
 

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -146,7 +146,7 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
     This also retrieves datetime from tif's metadata and stores it into dataset.
     """
 
-    def replace_dataarray_names_with_long_names(ds: xr.Dataset):
+    def _replace_dataarray_names_with_long_names(ds: xr.Dataset):
         rename_dict = {}
         for var_name in ds.variables:
             rename_dict[var_name] = ds[var_name].attrs.get('long_name', var_name)
@@ -163,7 +163,7 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
 
     ds = ds.squeeze().drop_vars('spatial_ref')
 
-    ds = replace_dataarray_names_with_long_names(ds)
+    ds = _replace_dataarray_names_with_long_names(ds)
 
     end_time = None
     if initialization_time_regex and forecast_time_regex:

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -49,7 +49,7 @@ base_requirements = [
     "netcdf4==1.6.1",
     "geojson==2.5.0",
     "simplejson==3.17.6",
-    "rioxarray==0.12.2",
+    "rioxarray==0.13.4",
     "metview==1.13.1",
     "rasterio==1.3.1",
     "earthengine-api>=0.1.263",


### PR DESCRIPTION
Using `rioxarray to` open .tiff file to get required meta data in the data set which was missing when the .tiff file was opened through `xr.open_dataset`.
Also upgrading rioxarray version from `0.12.0` -> `0.13.4` as that's the latest version that supports python 3.8 and has implemented the `band_as_variable` argument.

fixes #159 