### PR TITLE
Log warning instead at failure to parse projection info with rasterio.

### DIFF
--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -396,9 +396,12 @@ def open_dataset(uri: str,
                                              forecast_time_regex)
 
             # Extracting dtype, crs and transform from the dataset & storing them as attributes.
-            with rasterio.open(local_path, 'r') as f:
-                dtype, crs, transform = (f.profile.get(key) for key in ['dtype', 'crs', 'transform'])
-                xr_dataset.attrs.update({'dtype': dtype, 'crs': crs, 'transform': transform})
+            try:
+                with rasterio.open(local_path, 'r') as f:
+                    dtype, crs, transform = (f.profile.get(key) for key in ['dtype', 'crs', 'transform'])
+                    xr_dataset.attrs.update({'dtype': dtype, 'crs': crs, 'transform': transform})
+            except rasterio.errors.RasterioIOError:
+                logger.warning('Cannot parse projection and data type information for Dataset %r.', uri)
 
             logger.info(f'opened dataset size: {xr_dataset.nbytes}')
 


### PR DESCRIPTION
We use rasterio on open datasets to gather projection information and the datatype of data opened with `open_dataset()`. In cases where rasterio (or GDAL) cannot parse the URI, let's log a warning instead of crashing the pipeline.

When the CRS info is needed (in the `weather-mv ee` pipeline), users can pass this in via a custom COG conversion transform.

Fixes #347.