### PR TITLE
Added timedelta to json serialzation.

### DIFF
--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -117,6 +117,8 @@ def to_json_serializable_type(value: t.Any) -> t.Any:
 
         # We assume here that naive timestamps are in UTC timezone.
         return value.replace(tzinfo=datetime.timezone.utc).isoformat()
+    elif isinstance(value, datetime.timedelta):
+        return value.total_seconds()
     elif isinstance(value, np.timedelta64):
         # Return time delta in seconds.
         return float(value / np.timedelta64(1, 's'))

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -242,4 +242,4 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
         self.assertEqual(self._convert(np.timedelta64(1, 'm')), float(60))
         self.assertEqual(self._convert(timedelta(seconds=1)), float(1))
         self.assertEqual(self._convert(timedelta(minutes=1)), float(60))
-        self.assertEqual(self._convert(timedelta(days=1)), float(86400))        
+        self.assertEqual(self._convert(timedelta(days=1)), float(86400))

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -14,7 +14,7 @@
 import itertools
 import unittest
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import xarray
 import xarray as xr
@@ -240,3 +240,6 @@ class ToJsonSerializableTypeTests(unittest.TestCase):
         self.assertEqual(self._convert(np.datetime64(1, 'Y')), '1971-01-01T00:00:00+00:00')
         self.assertEqual(self._convert(np.datetime64(30, 'Y')), input_date)
         self.assertEqual(self._convert(np.timedelta64(1, 'm')), float(60))
+        self.assertEqual(self._convert(timedelta(seconds=1)), float(1))
+        self.assertEqual(self._convert(timedelta(minutes=1)), float(60))
+        self.assertEqual(self._convert(timedelta(days=1)), float(86400))        


### PR DESCRIPTION
Current implementation of `to_json_serializable_type()` only handles `np.timedelta` and was missing case of `datetime.timedelta`