### PR TITLE
Removing test data after clone in Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ARG weather_tools_git_rev=main
 RUN git clone https://github.com/google/weather-tools.git /weather
 WORKDIR /weather
 RUN git checkout "${weather_tools_git_rev}"
+RUN rm -r /weather/weather_*/test_data/
 RUN conda env create -f environment.yml --debug
 
 # Activate the conda env and update the PATH


### PR DESCRIPTION
I believe that our docker images are larger than they should be since they also include checked-in test data. This change adds a short-term fix to delete all `test_data` folders in each weather_tool before building the rest of the image.

In small experiments, this can save ~190 MiBs of disk space.

This is a band aid for #350.