### PR TITLE
Small fix to return correct hdate for leap days

### DIFF
--- a/weather_dl/download_pipeline/util.py
+++ b/weather_dl/download_pipeline/util.py
@@ -203,6 +203,8 @@ def download_with_aria2(url: str, path: str) -> None:
 
 def generate_hdate(date: str, subtract_year: str) -> str:
     """Generate a historical date by subtracting a specified number of years from the given date.
+    If input date is leap day (Feb 29), return Feb 28 even if target hdate is also a leap year.
+    This is expected in ECMWF API.
 
     Args:
         date (str): The input date in the format 'YYYY-MM-DD'.
@@ -213,6 +215,9 @@ def generate_hdate(date: str, subtract_year: str) -> str:
     """
     try:
         input_date = datetime.datetime.strptime(date, "%Y-%m-%d")
+        # Check for leap day
+        if input_date.month == 2 and input_date.day == 29:
+            input_date = input_date - datetime.timedelta(days=1)
         subtract_year = int(subtract_year)
     except (ValueError, TypeError):
         logger.error("Invalid input.")

--- a/weather_dl/download_pipeline/util_test.py
+++ b/weather_dl/download_pipeline/util_test.py
@@ -89,3 +89,14 @@ class TestGenerateHdate(unittest.TestCase):
         substract_year = '4'
         expected_result = '2016-01-02'
         self.assertEqual(generate_hdate(date, substract_year), expected_result)
+        
+        # Also test for leap day correctness
+        date = '2020-02-29'
+        substract_year = '3'
+        expected_result = '2017-02-28'
+        self.assertEqual(generate_hdate(date, substract_year), expected_result)
+        
+        substract_year = '4'
+        expected_result = '2016-02-28'
+        self.assertEqual(generate_hdate(date, substract_year), expected_result)
+        


### PR DESCRIPTION
ECMWF API expects day==28 for all hdates if input date is Feb 29, even if target hdate is also a leap year. Added small correction to fix this.