### PR TITLE
`weather-mv` will ingest data into BQ from Zarr much faster.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -n base conda-libmamba-solver
 RUN conda config --set solver libmamba
 
 # Create conda env using environment.yml
-ARG weather_tools_git_rev=mv-ba-fix-zarr
+ARG weather_tools_git_rev=main
 RUN git clone https://github.com/google/weather-tools.git /weather
 WORKDIR /weather
 RUN git checkout "${weather_tools_git_rev}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -n base conda-libmamba-solver
 RUN conda config --set solver libmamba
 
 # Create conda env using environment.yml
-ARG weather_tools_git_rev=main
+ARG weather_tools_git_rev=mv-ba-fix-zarr
 RUN git clone https://github.com/google/weather-tools.git /weather
 WORKDIR /weather
 RUN git checkout "${weather_tools_git_rev}"

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -16,7 +16,7 @@ dependencies:
   - requests=2.28.1
   - netcdf4=1.6.1
   - rioxarray=0.13.4
-  - xarray-beam=0.3.1
+  - xarray-beam=0.6.2
   - ecmwf-api-client=1.6.3
   - fsspec=2022.11.0
   - gcsfs=2022.11.0

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -33,6 +33,7 @@ dependencies:
   - ruff==0.0.260
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
+  - zarr=2.13.3
   - pip:
     - earthengine-api==0.1.329
     - .[test]

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -33,7 +33,7 @@ dependencies:
   - ruff==0.0.260
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
-  - zarr=2.13.3
+  - zarr=2.15.0
   - pip:
     - earthengine-api==0.1.329
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -33,6 +33,7 @@ dependencies:
   - aria2=1.36.0
   - xarray==2023.1.0
   - ruff==0.0.260
+  - zarr=2.13.3
   - pip:
     - earthengine-api==0.1.329
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -16,7 +16,7 @@ dependencies:
   - requests=2.28.1
   - netcdf4=1.6.1
   - rioxarray=0.13.4
-  - xarray-beam=0.3.1
+  - xarray-beam=0.6.2
   - ecmwf-api-client=1.6.3
   - fsspec=2022.11.0
   - gcsfs=2022.11.0

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -33,7 +33,7 @@ dependencies:
   - aria2=1.36.0
   - xarray==2023.1.0
   - ruff==0.0.260
-  - zarr=2.13.3
+  - zarr=2.15.0
   - pip:
     - earthengine-api==0.1.329
     - .[test]

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
   - pip=22.3
-  - zarr=2.13.3
+  - zarr=2.15.0
   - pip:
     - earthengine-api==0.1.329
     - firebase-admin==6.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
   - pip=22.3
+  - zarr=2.13.3
   - pip:
     - earthengine-api==0.1.329
     - firebase-admin==6.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8.13
   - apache-beam=2.40.0
-  - xarray-beam=0.3.1
+  - xarray-beam=0.6.2
   - xarray=2023.1.0
   - fsspec=2022.11.0
   - gcsfs=2022.11.0

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ weather_mv_requirements = [
     "gdal",  # requires separate binary installation!
     "xarray-beam==0.6.2",
     "gcsfs==2022.11.0",
+    "zarr==2.13.3",
 ]
 
 weather_sp_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
 
     ],
     python_requires='>=3.8, <3.10',
-    install_requires=['apache-beam[gcp]==2.40.0'],
+    install_requires=['apache-beam[gcp]==2.40.0', 'gcsfs==2022.11.0'],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     scripts=['weather_dl/weather-dl', 'weather_mv/weather-mv', 'weather_sp/weather-sp'],

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ weather_mv_requirements = [
     "gdal",  # requires separate binary installation!
     "xarray-beam==0.6.2",
     "gcsfs==2022.11.0",
-    "zarr==2.13.3",
+    "zarr==2.15.0",
 ]
 
 weather_sp_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ test_requirements = [
     "memray",
     "pytest-memray",
     "h5py",
+    "pooch",
 ]
 
 all_test_requirements = beam_gcp_requirements + weather_dl_requirements + \

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ weather_mv_requirements = [
     "earthengine-api>=0.1.263",
     "pyproj",  # requires separate binary installation!
     "gdal",  # requires separate binary installation!
-    "xarray-beam==0.3.1",
+    "xarray-beam==0.6.2",
     "gcsfs==2022.11.0",
 ]
 

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -240,7 +240,7 @@ class ToBigQuery(ToDataSink):
             data_ds: xr.Dataset = _only_target_vars(ds, self.variables)
             yield from self.to_rows(coordinates, data_ds, uri)
 
-    def to_rows(self, coordinates, ds, uri) -> t.Iterator[t.Dict]:
+    def to_rows(self, coordinates: t.List[t.Dict], ds: xr.Dataset, uri: str) -> t.Iterator[t.Dict]:
         first_ts_raw = (
             ds.time[0].values if isinstance(ds.time.values, np.ndarray)
             else ds.time.values
@@ -269,7 +269,6 @@ class ToBigQuery(ToDataSink):
             row[DATA_IMPORT_TIME_COLUMN] = self.import_time
             row[DATA_URI_COLUMN] = uri
             row[DATA_FIRST_STEP] = first_time_step
-
 
             longitude = ((row['longitude'] + 180) % 360) - 180
             row[GEO_POINT_COLUMN] = fetch_geo_point(row['latitude'], longitude)

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -301,7 +301,7 @@ class ToBigQuery(ToDataSink):
             )
         else:
             ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
-            ds = ds.sel(time=slice('2021-01-01', '2023-01-01'))
+            # ds = ds.sel(time=slice('2021-01-01', '2023-01-01'))
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths
@@ -318,7 +318,8 @@ class ToBigQuery(ToDataSink):
                 dataset=self.table.dataset_id,
                 table=self.table.table_id,
                 write_disposition=BigQueryDisposition.WRITE_APPEND,
-                create_disposition=BigQueryDisposition.CREATE_NEVER)
+                create_disposition=BigQueryDisposition.CREATE_NEVER,
+                method='STREAMING_INSERTS')
         )
 
 

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -301,6 +301,7 @@ class ToBigQuery(ToDataSink):
             )
         else:
             ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
+            ds = ds.sel(time=slice('2021-01-01', '2023-01-01'))
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -258,7 +258,7 @@ class ToBigQuery(ToDataSink):
             # Serialize coordinates.
             it = {k: to_json_serializable_type(v) for k, v in it.items()}
 
-                # Add indexed coordinates.
+            # Add indexed coordinates.
             row.update(it)
             # Add un-indexed coordinates.
             for c in row_ds.coords:

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -301,7 +301,7 @@ class ToBigQuery(ToDataSink):
             )
         else:
             # ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
-            ds = xr.open_dataset(self.first_uri, **self.xarray_open_dataset_kwargs, chunks=None)
+            ds = xr.open_zarr(self.first_uri, engine='zarr', **self.xarray_open_dataset_kwargs, chunks=None)
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -24,6 +24,7 @@ import apache_beam as beam
 import geojson
 import numpy as np
 import xarray as xr
+import xarray_beam as xbeam
 from apache_beam.io import WriteToBigQuery, BigQueryDisposition
 from apache_beam.options.pipeline_options import PipelineOptions
 from google.cloud import bigquery
@@ -236,56 +237,76 @@ class ToBigQuery(ToDataSink):
         with open_dataset(uri, self.xarray_open_dataset_kwargs, self.disable_grib_schema_normalization,
                           self.tif_metadata_for_datetime, is_zarr=self.zarr) as ds:
             data_ds: xr.Dataset = _only_target_vars(ds, self.variables)
+            yield from self.to_rows(coordinates, data_ds, uri)
 
-            first_ts_raw = data_ds.time[0].values if isinstance(data_ds.time.values,
-                                                                np.ndarray) else data_ds.time.values
-            first_time_step = to_json_serializable_type(first_ts_raw)
+    def to_rows(self, coordinates, ds, uri) -> t.Iterator[t.Dict]:
+        first_ts_raw = (
+            ds.time[0].values if isinstance(ds.time.values, np.ndarray)
+            else ds.time.values
+        )
+        first_time_step = to_json_serializable_type(first_ts_raw)
+        for it in coordinates:
+            # Use those index values to select a Dataset containing one row of data.
+            row_ds = ds.loc[it]
 
-            for it in coordinates:
-                # Use those index values to select a Dataset containing one row of data.
-                row_ds = data_ds.loc[it]
+            # Create a Name-Value map for data columns. Result looks like:
+            # {'d': -2.0187, 'cc': 0.007812, 'z': 50049.8, 'rr': None}
+            row = {n: to_json_serializable_type(ensure_us_time_resolution(v.values))
+                   for n, v in row_ds.data_vars.items()}
 
-                # Create a Name-Value map for data columns. Result looks like:
-                # {'d': -2.0187, 'cc': 0.007812, 'z': 50049.8, 'rr': None}
-                row = {n: to_json_serializable_type(ensure_us_time_resolution(v.values))
-                       for n, v in row_ds.data_vars.items()}
-
-                # Serialize coordinates.
-                it = {k: to_json_serializable_type(v) for k, v in it.items()}
+            # Serialize coordinates.
+            it = {k: to_json_serializable_type(v) for k, v in it.items()}
 
                 # Add indexed coordinates.
-                row.update(it)
-                # Add un-indexed coordinates.
-                for c in row_ds.coords:
-                    if c not in it and (not self.variables or c in self.variables):
-                        row[c] = to_json_serializable_type(ensure_us_time_resolution(row_ds[c].values))
+            row.update(it)
+            # Add un-indexed coordinates.
+            for c in row_ds.coords:
+                if c not in it and (not self.variables or c in self.variables):
+                    row[c] = to_json_serializable_type(ensure_us_time_resolution(row_ds[c].values))
 
-                # Add import metadata.
-                row[DATA_IMPORT_TIME_COLUMN] = self.import_time
-                row[DATA_URI_COLUMN] = uri
-                row[DATA_FIRST_STEP] = first_time_step
+            # Add import metadata.
+            row[DATA_IMPORT_TIME_COLUMN] = self.import_time
+            row[DATA_URI_COLUMN] = uri
+            row[DATA_FIRST_STEP] = first_time_step
 
-                longitude = ((row['longitude'] + 180) % 360) - 180
-                row[GEO_POINT_COLUMN] = fetch_geo_point(row['latitude'], longitude)
-                row[GEO_POLYGON_COLUMN] = (
-                    fetch_geo_polygon(row["latitude"], longitude, self.lat_grid_resolution, self.lon_grid_resolution)
-                    if not self.skip_creating_polygon
-                    else None
-                )
-                # 'row' ends up looking like:
-                # {'latitude': 88.0, 'longitude': 2.0, 'time': '2015-01-01 06:00:00', 'd': -2.0187, 'cc': 0.007812,
-                #  'z': 50049.8, 'data_import_time': '2020-12-05 00:12:02.424573 UTC', ...}
-                beam.metrics.Metrics.counter('Success', 'ExtractRows').inc()
-                yield row
+
+            longitude = ((row['longitude'] + 180) % 360) - 180
+            row[GEO_POINT_COLUMN] = fetch_geo_point(row['latitude'], longitude)
+            row[GEO_POLYGON_COLUMN] = (
+                fetch_geo_polygon(row["latitude"], longitude, self.lat_grid_resolution, self.lon_grid_resolution)
+                if not self.skip_creating_polygon
+                else None
+            )
+            # 'row' ends up looking like:
+            # {'latitude': 88.0, 'longitude': 2.0, 'time': '2015-01-01 06:00:00', 'd': -2.0187, 'cc': 0.007812,
+            #  'z': 50049.8, 'data_import_time': '2020-12-05 00:12:02.424573 UTC', ...}
+            beam.metrics.Metrics.counter('Success', 'ExtractRows').inc()
+            yield row
+
+    def chunks_to_rows(self, _, ds: xr.Dataset) -> t.Iterator[t.Dict]:
+        uri = ds.attrs.get(DATA_URI_COLUMN, '')
+        # Re-calculate import time for streaming extractions.
+        if not self.import_time:
+            self.import_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        yield from self.to_rows(get_coordinates(ds, uri), ds, uri)
 
     def expand(self, paths):
         """Extract rows of variables from data paths into a BigQuery table."""
-        extracted_rows = (
+        if not self.zarr:
+            extracted_rows = (
+                    paths
+                    | 'PrepareCoordinates' >> beam.FlatMap(self.prepare_coordinates)
+                    | beam.Reshuffle()
+                    | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
+            )
+        else:
+            ds, chunks = xbeam.open_zarr(self.first_uri)
+            ds.attrs[DATA_URI_COLUMN] = self.first_uri
+            extracted_rows = (
                 paths
-                | 'PrepareCoordinates' >> beam.FlatMap(self.prepare_coordinates)
-                | beam.Reshuffle()
-                | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
-        )
+                | 'OpenChunks' >> xbeam.DatasetToChunks(ds, chunks)
+                | 'ExtractRows' >> beam.FlatMapTuple(self.chunks_to_rows)
+            )
 
         if not self.dry_run:
             (

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -322,8 +322,7 @@ class ToBigQuery(ToDataSink):
                 dataset=self.table.dataset_id,
                 table=self.table.table_id,
                 write_disposition=BigQueryDisposition.WRITE_APPEND,
-                create_disposition=BigQueryDisposition.CREATE_NEVER,
-                method='STREAMING_INSERTS')
+                create_disposition=BigQueryDisposition.CREATE_NEVER)
         )
 
 

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -300,11 +300,12 @@ class ToBigQuery(ToDataSink):
                 | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
             )
         else:
-            ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
+            # ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
+            ds = xr.open_dataset(self.first_uri, **self.xarray_open_dataset_kwargs, chunks=None)
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths
-                | 'OpenChunks' >> xbeam.DatasetToChunks(ds, chunks)
+                | 'OpenChunks' >> xbeam.DatasetToChunks(ds, {'time': 240})
                 | 'ExtractRows' >> beam.FlatMapTuple(self.chunks_to_rows)
             )
 

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -367,6 +367,7 @@ def to_table_schema(columns: t.List[t.Tuple[str, str]]) -> t.List[bigquery.Schem
 
 
 def timestamp_row(it: t.Dict) -> window.TimestampedValue:
+    """Associate an extracted row with the import_time timestamp."""
     timestamp = it[DATA_IMPORT_TIME_COLUMN].timestamp()
     return window.TimestampedValue(it, timestamp)
 

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -294,10 +294,10 @@ class ToBigQuery(ToDataSink):
         """Extract rows of variables from data paths into a BigQuery table."""
         if not self.zarr:
             extracted_rows = (
-                    paths
-                    | 'PrepareCoordinates' >> beam.FlatMap(self.prepare_coordinates)
-                    | beam.Reshuffle()
-                    | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
+                paths
+                | 'PrepareCoordinates' >> beam.FlatMap(self.prepare_coordinates)
+                | beam.Reshuffle()
+                | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
             )
         else:
             ds, chunks = xbeam.open_zarr(self.first_uri)

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -301,7 +301,6 @@ class ToBigQuery(ToDataSink):
                 | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
             )
         else:
-
             ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
             # ds = ds.sel(time=slice('2021-01-01', '2023-01-01'))
             ds.attrs[DATA_URI_COLUMN] = self.first_uri

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -240,7 +240,7 @@ class ToBigQuery(ToDataSink):
             data_ds: xr.Dataset = _only_target_vars(ds, self.variables)
             yield from self.to_rows(coordinates, data_ds, uri)
 
-    def to_rows(self, coordinates: t.List[t.Dict], ds: xr.Dataset, uri: str) -> t.Iterator[t.Dict]:
+    def to_rows(self, coordinates: t.Iterable[t.Dict], ds: xr.Dataset, uri: str) -> t.Iterator[t.Dict]:
         first_ts_raw = (
             ds.time[0].values if isinstance(ds.time.values, np.ndarray)
             else ds.time.values

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -302,7 +302,6 @@ class ToBigQuery(ToDataSink):
             )
         else:
             ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
-            # ds = ds.sel(time=slice('2021-01-01', '2023-01-01'))
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -198,9 +198,6 @@ class ToBigQuery(ToDataSink):
                 ds: xr.Dataset = _only_target_vars(open_ds, self.variables)
                 table_schema = dataset_to_table_schema(ds)
 
-                del ds
-            del open_ds
-
         if self.dry_run:
             logger.debug('Created the BigQuery table with schema...')
             logger.debug(f'\n{pformat(table_schema)}')
@@ -310,6 +307,9 @@ class ToBigQuery(ToDataSink):
                 | 'OpenChunks' >> xbeam.DatasetToChunks(ds, chunks)
                 | 'ExtractRows' >> beam.FlatMapTuple(self.chunks_to_rows)
             )
+
+            # Fixes pickling error.
+            del ds
 
         if self.dry_run:
             return extracted_rows | 'Log Rows' >> beam.Map(logger.info)

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -308,21 +308,17 @@ class ToBigQuery(ToDataSink):
                 | 'ExtractRows' >> beam.FlatMapTuple(self.chunks_to_rows)
             )
 
-        if not self.dry_run:
-            (
-                    extracted_rows
-                    | 'WriteToBigQuery' >> WriteToBigQuery(
-                        project=self.table.project,
-                        dataset=self.table.dataset_id,
-                        table=self.table.table_id,
-                        write_disposition=BigQueryDisposition.WRITE_APPEND,
-                        create_disposition=BigQueryDisposition.CREATE_NEVER)
-            )
-        else:
-            (
-                    extracted_rows
-                    | 'Log Extracted Rows' >> beam.Map(logger.debug)
-            )
+        if self.dry_run:
+            return extracted_rows | 'Log Rows' >> beam.Map(logger.info)
+        return (
+            extracted_rows
+            | 'WriteToBigQuery' >> WriteToBigQuery(
+                project=self.table.project,
+                dataset=self.table.dataset_id,
+                table=self.table.table_id,
+                write_disposition=BigQueryDisposition.WRITE_APPEND,
+                create_disposition=BigQueryDisposition.CREATE_NEVER)
+        )
 
 
 def map_dtype_to_sql_type(var_type: np.dtype) -> str:

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -198,6 +198,9 @@ class ToBigQuery(ToDataSink):
                 ds: xr.Dataset = _only_target_vars(open_ds, self.variables)
                 table_schema = dataset_to_table_schema(ds)
 
+                del ds
+            del open_ds
+
         if self.dry_run:
             logger.debug('Created the BigQuery table with schema...')
             logger.debug(f'\n{pformat(table_schema)}')

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -300,7 +300,7 @@ class ToBigQuery(ToDataSink):
                 | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
             )
         else:
-            ds, chunks = xbeam.open_zarr(self.first_uri)
+            ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -300,16 +300,15 @@ class ToBigQuery(ToDataSink):
                 | 'ExtractRows' >> beam.FlatMapTuple(self.extract_rows)
             )
         else:
-            # ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
-            ds = xr.open_dataset(self.first_uri, engine='zarr', **self.xarray_open_dataset_kwargs, chunks=None)
+            ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths
-                | 'OpenChunks' >> xbeam.DatasetToChunks(ds, {'time': 240})
+                | 'OpenChunks' >> xbeam.DatasetToChunks(ds, chunks)
                 | 'ExtractRows' >> beam.FlatMapTuple(self.chunks_to_rows)
             )
 
-            # Fixes pickling error.
+            # Fixes pickling error?
             del ds
 
         if self.dry_run:

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -301,7 +301,7 @@ class ToBigQuery(ToDataSink):
             )
         else:
             # ds, chunks = xbeam.open_zarr(self.first_uri, **self.xarray_open_dataset_kwargs)
-            ds = xr.open_zarr(self.first_uri, engine='zarr', **self.xarray_open_dataset_kwargs, chunks=None)
+            ds = xr.open_dataset(self.first_uri, engine='zarr', **self.xarray_open_dataset_kwargs, chunks=None)
             ds.attrs[DATA_URI_COLUMN] = self.first_uri
             extracted_rows = (
                 paths

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -308,9 +308,6 @@ class ToBigQuery(ToDataSink):
                 | 'ExtractRows' >> beam.FlatMapTuple(self.chunks_to_rows)
             )
 
-            # Fixes pickling error?
-            del ds
-
         if self.dry_run:
             return extracted_rows | 'Log Rows' >> beam.Map(logger.info)
         return (

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -213,8 +213,8 @@ class ExtractRowsTestBase(TestDataBase):
             output_table='foo.bar.baz', variables=variables, area=area,
             xarray_open_dataset_kwargs=open_dataset_kwargs, import_time=import_time, infer_schema=False,
             tif_metadata_for_datetime=tif_metadata_for_datetime, skip_region_validation=True,
-            disable_grib_schema_normalization=disable_grib_schema_normalization, coordinate_chunk_size=1000
-        , skip_creating_polygon=skip_creating_polygon)
+            disable_grib_schema_normalization=disable_grib_schema_normalization, coordinate_chunk_size=1000,
+            skip_creating_polygon=skip_creating_polygon)
         coords = op.prepare_coordinates(data_path)
         for uri, chunk in coords:
             yield from op.extract_rows(uri, chunk)

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -19,13 +19,13 @@ import tempfile
 import typing as t
 import unittest
 
-from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that, is_not_empty
 import geojson
 import numpy as np
 import pandas as pd
 import simplejson
 import xarray as xr
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that, is_not_empty
 from google.cloud.bigquery import SchemaField
 
 from .bq import (

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -15,9 +15,12 @@ import datetime
 import json
 import logging
 import os
+import tempfile
 import typing as t
 import unittest
 
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that, is_not_empty
 import geojson
 import numpy as np
 import pandas as pd
@@ -205,13 +208,13 @@ class ExtractRowsTestBase(TestDataBase):
                 skip_creating_polygon: bool = False) -> t.Iterator[t.Dict]:
         if zarr_kwargs is None:
             zarr_kwargs = {}
-        op = ToBigQuery.from_kwargs(first_uri=data_path, dry_run=True, zarr=zarr, zarr_kwargs=zarr_kwargs,
-                                    output_table='foo.bar.baz', variables=variables, area=area,
-                                    xarray_open_dataset_kwargs=open_dataset_kwargs, import_time=import_time,
-                                    infer_schema=False, tif_metadata_for_datetime=tif_metadata_for_datetime,
-                                    skip_region_validation=True,
-                                    disable_grib_schema_normalization=disable_grib_schema_normalization,
-                                    coordinate_chunk_size=1000, skip_creating_polygon=skip_creating_polygon)
+        op = ToBigQuery.from_kwargs(
+            first_uri=data_path, dry_run=True, zarr=zarr, zarr_kwargs=zarr_kwargs,
+            output_table='foo.bar.baz', variables=variables, area=area,
+            xarray_open_dataset_kwargs=open_dataset_kwargs, import_time=import_time, infer_schema=False,
+            tif_metadata_for_datetime=tif_metadata_for_datetime, skip_region_validation=True,
+            disable_grib_schema_normalization=disable_grib_schema_normalization, coordinate_chunk_size=1000
+        , skip_creating_polygon=skip_creating_polygon)
         coords = op.prepare_coordinates(data_path)
         for uri, chunk in coords:
             yield from op.extract_rows(uri, chunk)
@@ -735,6 +738,37 @@ class ExtractRowsGribSupportTest(ExtractRowsTestBase):
 
         }
         self.assertRowsEqual(actual, expected)
+
+
+class ExtractRowsFromZarrTest(ExtractRowsTestBase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.tmpdir.cleanup()
+
+    def test_extracts_rows(self):
+        input_zarr = os.path.join(self.tmpdir.name, 'air_temp.zarr')
+
+        ds = (
+            xr.tutorial.open_dataset('air_temperature', cache_dir=self.test_data_folder)
+            .isel(time=slice(0, 4), lat=slice(0, 4), lon=slice(0, 4))
+            .rename(dict(lon='longitude', lat='latitude'))
+        )
+        ds.to_zarr(input_zarr)
+
+        op = ToBigQuery.from_kwargs(
+            first_uri=input_zarr, zarr_kwargs=dict(), dry_run=True, zarr=True, output_table='foo.bar.baz',
+            variables=list(), area=list(), xarray_open_dataset_kwargs=dict(), import_time=None, infer_schema=False,
+            tif_metadata_for_datetime=None, skip_region_validation=True, disable_grib_schema_normalization=False,
+        )
+
+        with TestPipeline() as p:
+            result = p | op
+            assert_that(result, is_not_empty())
 
 
 if __name__ == '__main__':

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -22,6 +22,7 @@ import apache_beam as beam
 from apache_beam.io.filesystems import FileSystems
 
 from .bq import ToBigQuery
+from .regrid import Regrid
 from .ee import ToEarthEngine
 from .streaming import GroupMessagesByFixedWindows, ParsePaths
 
@@ -70,6 +71,8 @@ def pipeline(known_args: argparse.Namespace, pipeline_args: t.List[str]) -> None
 
         if known_args.subcommand == 'bigquery' or known_args.subcommand == 'bq':
             paths | "MoveToBigQuery" >> ToBigQuery.from_kwargs(**vars(known_args))
+        elif known_args.subcommand == 'regrid' or known_args.subcommand == 'rg':
+            paths | "Regrid" >> Regrid.from_kwargs(**vars(known_args))
         elif known_args.subcommand == 'earthengine' or known_args.subcommand == 'ee':
             paths | "MoveToEarthEngine" >> ToEarthEngine.from_kwargs(**vars(known_args))
         else:
@@ -121,6 +124,11 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
                                       help='Move data into Google BigQuery')
     ToBigQuery.add_parser_arguments(bq_parser)
 
+    # Regrid command registration
+    rg_parser = subparsers.add_parser('regrid', aliases=['rg'], parents=[base],
+                                      help='Copy and regrid grib data with MetView.')
+    Regrid.add_parser_arguments(rg_parser)
+
     # EarthEngine command registration
     ee_parser = subparsers.add_parser('earthengine', aliases=['ee'], parents=[base],
                                       help='Move data into Google EarthEngine')
@@ -141,6 +149,8 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
     # Validate subcommand
     if known_args.subcommand == 'bigquery' or known_args.subcommand == 'bq':
         ToBigQuery.validate_arguments(known_args, pipeline_args)
+    elif known_args.subcommand == 'regrid' or known_args.subcommand == 'rg':
+        Regrid.validate_arguments(known_args, pipeline_args)
     elif known_args.subcommand == 'earthengine' or known_args.subcommand == 'ee':
         ToEarthEngine.validate_arguments(known_args, pipeline_args)
 

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -55,8 +55,9 @@ def pipeline(known_args: argparse.Namespace, pipeline_args: t.List[str]) -> None
     known_args.first_uri = next(iter(all_uris))
 
     with beam.Pipeline(argv=pipeline_args) as p:
-        if known_args.topic or known_args.subscription:
-
+        if known_args.zarr:
+            paths = p
+        elif known_args.topic or known_args.subscription:
             paths = (
                     p
                     # Windowing is based on this code sample:

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -27,7 +27,7 @@ from .ee import ToEarthEngine
 from .streaming import GroupMessagesByFixedWindows, ParsePaths
 
 logger = logging.getLogger(__name__)
-SDK_CONTAINER_IMAGE='gcr.io/weather-tools-prod/weather-tools:0.0.0'
+SDK_CONTAINER_IMAGE = 'gcr.io/weather-tools-prod/weather-tools:0.0.0'
 
 
 def configure_logger(verbosity: int) -> None:

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -22,7 +22,6 @@ import apache_beam as beam
 from apache_beam.io.filesystems import FileSystems
 
 from .bq import ToBigQuery
-from .regrid import Regrid
 from .ee import ToEarthEngine
 from .streaming import GroupMessagesByFixedWindows, ParsePaths
 
@@ -71,8 +70,6 @@ def pipeline(known_args: argparse.Namespace, pipeline_args: t.List[str]) -> None
 
         if known_args.subcommand == 'bigquery' or known_args.subcommand == 'bq':
             paths | "MoveToBigQuery" >> ToBigQuery.from_kwargs(**vars(known_args))
-        elif known_args.subcommand == 'regrid' or known_args.subcommand == 'rg':
-            paths | "Regrid" >> Regrid.from_kwargs(**vars(known_args))
         elif known_args.subcommand == 'earthengine' or known_args.subcommand == 'ee':
             paths | "MoveToEarthEngine" >> ToEarthEngine.from_kwargs(**vars(known_args))
         else:
@@ -124,11 +121,6 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
                                       help='Move data into Google BigQuery')
     ToBigQuery.add_parser_arguments(bq_parser)
 
-    # Regrid command registration
-    rg_parser = subparsers.add_parser('regrid', aliases=['rg'], parents=[base],
-                                      help='Copy and regrid grib data with MetView.')
-    Regrid.add_parser_arguments(rg_parser)
-
     # EarthEngine command registration
     ee_parser = subparsers.add_parser('earthengine', aliases=['ee'], parents=[base],
                                       help='Move data into Google EarthEngine')
@@ -149,8 +141,6 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
     # Validate subcommand
     if known_args.subcommand == 'bigquery' or known_args.subcommand == 'bq':
         ToBigQuery.validate_arguments(known_args, pipeline_args)
-    elif known_args.subcommand == 'regrid' or known_args.subcommand == 'rg':
-        Regrid.validate_arguments(known_args, pipeline_args)
     elif known_args.subcommand == 'earthengine' or known_args.subcommand == 'ee':
         ToEarthEngine.validate_arguments(known_args, pipeline_args)
 

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -141,7 +141,6 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
     # Validate Zarr arguments
     if known_args.uris.endswith('.zarr'):
         known_args.zarr = True
-        known_args.zarr_kwargs['chunks'] = known_args.zarr_kwargs.get('chunks', None)
 
     if known_args.zarr_kwargs and not known_args.zarr:
         raise ValueError('`--zarr_kwargs` argument is only allowed with valid Zarr input URI.')

--- a/weather_mv/loader_pipeline/regrid_test.py
+++ b/weather_mv/loader_pipeline/regrid_test.py
@@ -122,7 +122,7 @@ class RegridTest(TestDataBase):
             self.Op,
             first_uri=input_zarr,
             output_path=output_zarr,
-            zarr_input_chunks={"time": 5},
+            zarr_input_chunks={"time": 25},
             zarr=True
         )
 

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -176,8 +176,10 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
 
     datetime_value_ms = None
     try:
-        datetime_value_s = (int(end_time.timestamp()) if end_time is not None
-                        else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0)
+        datetime_value_s = (
+            int(end_time.timestamp()) if end_time is not None
+            else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0
+        )
         ds = ds.assign_coords({'time': datetime.datetime.utcfromtimestamp(datetime_value_s)})
     except KeyError:
         raise RuntimeError(f"Invalid datetime metadata of tif: {tif_metadata_for_datetime}.")

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -375,7 +375,7 @@ def open_dataset(uri: str,
     """Open the dataset at 'uri' and return a xarray.Dataset."""
     try:
         if is_zarr:
-            ds: xr.Dataset = _add_is_normalized_attr(xr.open_dataset(uri, engine='zarr', **open_dataset_kwargs))
+            ds: xr.Dataset = _add_is_normalized_attr(xr.open_dataset(uri, engine='zarr', **open_dataset_kwargs), False)
             beam.metrics.Metrics.counter('Success', 'ReadNetcdfData').inc()
             yield ds
             ds.close()

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -375,7 +375,7 @@ def open_dataset(uri: str,
     """Open the dataset at 'uri' and return a xarray.Dataset."""
     try:
         if is_zarr:
-            ds: xr.Dataset = xr.open_dataset(uri, engine='zarr', **open_dataset_kwargs)
+            ds: xr.Dataset = _add_is_normalized_attr(xr.open_dataset(uri, engine='zarr', **open_dataset_kwargs))
             beam.metrics.Metrics.counter('Success', 'ReadNetcdfData').inc()
             yield ds
             ds.close()

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -176,10 +176,8 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
 
     datetime_value_ms = None
     try:
-        datetime_value_s = (
-            int(end_time.timestamp()) if end_time is not None
-            else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0
-        )
+        datetime_value_s = (int(end_time.timestamp()) if end_time is not None
+                        else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0)
         ds = ds.assign_coords({'time': datetime.datetime.utcfromtimestamp(datetime_value_s)})
     except KeyError:
         raise RuntimeError(f"Invalid datetime metadata of tif: {tif_metadata_for_datetime}.")

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -177,7 +177,7 @@ def _preprocess_tif(ds: xr.Dataset, filename: str, tif_metadata_for_datetime: st
     datetime_value_ms = None
     try:
         datetime_value_s = (int(end_time.timestamp()) if end_time is not None
-                        else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0)
+                            else int(ds.attrs[tif_metadata_for_datetime]) / 1000.0)
         ds = ds.assign_coords({'time': datetime.datetime.utcfromtimestamp(datetime_value_s)})
     except KeyError:
         raise RuntimeError(f"Invalid datetime metadata of tif: {tif_metadata_for_datetime}.")

--- a/weather_mv/loader_pipeline/sinks_test.py
+++ b/weather_mv/loader_pipeline/sinks_test.py
@@ -112,6 +112,7 @@ class OpenDatasetTest(TestDataBase):
         with open_dataset(self.test_zarr_path, is_zarr=True, open_dataset_kwargs={}) as ds:
             self.assertIsNotNone(ds)
             self.assertEqual(list(ds.data_vars), ['cape', 'd2m'])
+
     def test_open_dataset__fits_memory_bounds(self):
         with write_netcdf() as test_netcdf_path:
             with limit_memory(max_memory=30):

--- a/weather_mv/loader_pipeline/util_test.py
+++ b/weather_mv/loader_pipeline/util_test.py
@@ -38,9 +38,10 @@ class GetCoordinatesTest(TestDataBase):
         ds = xr.open_dataset(self.test_data_path)
         self.assertEqual(
             next(get_coordinates(ds)),
-            {'latitude': 49.0,
-             'longitude':-108.0,
-             'time': datetime.fromisoformat('2018-01-02T06:00:00+00:00').replace(tzinfo=None)}
+            {
+                'latitude': 49.0,
+                'longitude': -108.0,
+                'time': datetime.fromisoformat('2018-01-02T06:00:00+00:00').replace(tzinfo=None)}
         )
 
     def test_no_duplicate_coordinates(self):
@@ -91,24 +92,28 @@ class IChunksTests(TestDataBase):
             actual,
             [
                 [
-                    {'longitude': -108.0,
-                     'latitude': 49.0,
-                     'time': datetime.fromisoformat('2018-01-02T06:00:00+00:00').replace(tzinfo=None)
+                    {
+                        'longitude': -108.0,
+                        'latitude': 49.0,
+                        'time': datetime.fromisoformat('2018-01-02T06:00:00+00:00').replace(tzinfo=None)
                     },
-                    {'longitude': -108.0,
-                     'latitude': 49.0,
-                     'time': datetime.fromisoformat('2018-01-02T07:00:00+00:00').replace(tzinfo=None)
+                    {
+                        'longitude': -108.0,
+                        'latitude': 49.0,
+                        'time': datetime.fromisoformat('2018-01-02T07:00:00+00:00').replace(tzinfo=None)
                     },
-                    {'longitude': -108.0,
-                     'latitude': 49.0,
-                     'time': datetime.fromisoformat('2018-01-02T08:00:00+00:00').replace(tzinfo=None)
+                    {
+                        'longitude': -108.0,
+                        'latitude': 49.0,
+                        'time': datetime.fromisoformat('2018-01-02T08:00:00+00:00').replace(tzinfo=None)
                     },
                 ],
                 [
-                    {'longitude': -108.0,
-                     'latitude': 49.0,
-                     'time': datetime.fromisoformat('2018-01-02T09:00:00+00:00').replace(tzinfo=None)
-                    }
+                    {
+                        'longitude': -108.0,
+                        'latitude': 49.0,
+                        'time': datetime.fromisoformat('2018-01-02T09:00:00+00:00').replace(tzinfo=None)
+                     }
                 ]
             ]
         )

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -57,7 +57,7 @@ base_requirements = [
     "pyproj==3.4.0",  # requires separate binary installation!
     "gdal==3.5.1",  # requires separate binary installation!
     "gcsfs==2022.11.0",
-    "zarr==2.13.3",
+    "zarr==2.15.0",
 ]
 
 setup(

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -45,7 +45,7 @@ base_requirements = [
     "numpy==1.22.4",
     "pandas==1.5.1",
     "xarray==2023.1.0",
-    "xarray-beam=0.6.2",
+    "xarray-beam==0.6.2",
     "cfgrib==0.9.10.2",
     "netcdf4==1.6.1",
     "geojson==2.5.0",

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -55,6 +55,7 @@ base_requirements = [
     "earthengine-api>=0.1.263",
     "pyproj==3.4.0",  # requires separate binary installation!
     "gdal==3.5.1",  # requires separate binary installation!
+    "gcsfs==2022.11.0",
 ]
 
 setup(

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -57,6 +57,7 @@ base_requirements = [
     "pyproj==3.4.0",  # requires separate binary installation!
     "gdal==3.5.1",  # requires separate binary installation!
     "gcsfs==2022.11.0",
+    "zarr==2.13.3",
 ]
 
 setup(

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -45,6 +45,7 @@ base_requirements = [
     "numpy==1.22.4",
     "pandas==1.5.1",
     "xarray==2023.1.0",
+    "xarray-beam=0.6.2",
     "cfgrib==0.9.10.2",
     "netcdf4==1.6.1",
     "geojson==2.5.0",


### PR DESCRIPTION
`weather-mv bq`'s previous Zarr ingestion system only used one worker. This PR uses Xarray-Beam for Zarr ingestion, in order to distributed `xr.Dataset` chunks across beam workers. This improves ingestion into BQ. 

_Outstanding issues_: I can't find a way to incrementally load rows into BQ from Zarr. While I've used windowing on fixed intervals to break up a large ingestion job into smaller parts, it seems like the actual writing to BQ gets stuck in a reshuffle step within the `WriteToBigQuery` transform. In this PR or a future PR, let's try to find a way to incrementally write rows to BQ once they've been processed, instead of having to wait for the entire dataset to be processed. CC: @dabhicusp.