### PR TITLE
Added time metrics to `weather-mv` ee

### DIFF
--- a/weather_mv/loader_pipeline/ee.py
+++ b/weather_mv/loader_pipeline/ee.py
@@ -449,6 +449,8 @@ class ConvertToAsset(beam.DoFn, beam.PTransform, KwargsFactoryMixin):
                                                    ('start_time', 'end_time', 'is_normalized'))
             dtype, crs, transform = (attrs.pop(key) for key in ['dtype', 'crs', 'transform'])
             attrs.update({'is_normalized': str(is_normalized)})  # EE properties does not support bool.
+            # Adding job_start_time to properites.
+            attrs["job_start_time"] = job_start_time
             # Make attrs EE ingestable.
             attrs = make_attrs_ee_compatible(attrs)
 
@@ -499,9 +501,6 @@ class ConvertToAsset(beam.DoFn, beam.PTransform, KwargsFactoryMixin):
                     tmp_df.seek(0)
                     with FileSystems().create(target_path) as dst:
                         shutil.copyfileobj(tmp_df, dst, WRITE_CHUNK_SIZE)
-
-            # Adding job_start_time to properites.
-            attrs["job_start_time"] = job_start_time
 
             asset_data = AssetData(
                 name=asset_name,

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -28,7 +28,7 @@ import typing as t
 import uuid
 from functools import partial
 from urllib.parse import urlparse
-
+from datetime import timezone
 import apache_beam as beam
 import numpy as np
 import pandas as pd
@@ -134,6 +134,10 @@ def _check_for_coords_vars(ds_data_var: str, target_var: str) -> bool:
     specified by the user."""
     return ds_data_var.endswith('_'+target_var) or ds_data_var.startswith(target_var+'_')
 
+def get_utc_timestamp():
+    dt = datetime.datetime.now(timezone.utc)
+    utc_time = dt.replace(tzinfo=timezone.utc)
+    return utc_time.isoformat() 
 
 def _only_target_coordinate_vars(ds: xr.Dataset, data_vars: t.List[str]) -> t.List[str]:
     """If the user specifies target fields in the dataset, get all the matching coords & data vars."""

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -135,9 +135,11 @@ def _check_for_coords_vars(ds_data_var: str, target_var: str) -> bool:
     return ds_data_var.endswith('_'+target_var) or ds_data_var.startswith(target_var+'_')
 
 def get_utc_timestamp():
+    """Returns the current UTC Timestamp as ISO datetime string."""
     dt = datetime.datetime.now(timezone.utc)
     utc_time = dt.replace(tzinfo=timezone.utc)
-    return utc_time.isoformat() 
+
+    return utc_time.isoformat()
 
 def _only_target_coordinate_vars(ds: xr.Dataset, data_vars: t.List[str]) -> t.List[str]:
     """If the user specifies target fields in the dataset, get all the matching coords & data vars."""

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -134,7 +134,7 @@ def _check_for_coords_vars(ds_data_var: str, target_var: str) -> bool:
     specified by the user."""
     return ds_data_var.endswith('_'+target_var) or ds_data_var.startswith(target_var+'_')
 
-def get_utc_timestamp():
+def get_utc_timestamp() -> str:
     """Returns the current UTC Timestamp as ISO datetime string."""
     dt = datetime.datetime.now(timezone.utc)
     utc_time = dt.replace(tzinfo=timezone.utc)

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -134,12 +134,12 @@ def _check_for_coords_vars(ds_data_var: str, target_var: str) -> bool:
     specified by the user."""
     return ds_data_var.endswith('_'+target_var) or ds_data_var.startswith(target_var+'_')
 
-def get_utc_timestamp() -> str:
+def get_utc_timestamp() -> float:
     """Returns the current UTC Timestamp as ISO datetime string."""
     dt = datetime.datetime.now(timezone.utc)
     utc_time = dt.replace(tzinfo=timezone.utc)
 
-    return utc_time.isoformat()
+    return utc_time.timestamp()
 
 def _only_target_coordinate_vars(ds: xr.Dataset, data_vars: t.List[str]) -> t.List[str]:
     """If the user specifies target fields in the dataset, get all the matching coords & data vars."""

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -28,7 +28,6 @@ import typing as t
 import uuid
 from functools import partial
 from urllib.parse import urlparse
-from datetime import timezone
 import apache_beam as beam
 import numpy as np
 import pandas as pd

--- a/weather_mv/loader_pipeline/util.py
+++ b/weather_mv/loader_pipeline/util.py
@@ -135,11 +135,8 @@ def _check_for_coords_vars(ds_data_var: str, target_var: str) -> bool:
     return ds_data_var.endswith('_'+target_var) or ds_data_var.startswith(target_var+'_')
 
 def get_utc_timestamp() -> float:
-    """Returns the current UTC Timestamp as ISO datetime string."""
-    dt = datetime.datetime.now(timezone.utc)
-    utc_time = dt.replace(tzinfo=timezone.utc)
-
-    return utc_time.timestamp()
+    """Returns the current UTC Timestamp."""
+    return datetime.datetime.now().timestamp()
 
 def _only_target_coordinate_vars(ds: xr.Dataset, data_vars: t.List[str]) -> t.List[str]:
     """If the user specifies target fields in the dataset, get all the matching coords & data vars."""


### PR DESCRIPTION
Added 
`job_start_time`: timestamp of the beginning of convert to asset
`injestion_time`: timestamp of the start of ingestion into earth engine.

The time stamps are ISO date time strings adjusted to the UCT time zone.

fixes: #360 