### PR TITLE
Pinned cython version to 0.29.34.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         id: pip-cache
         run: |
           python -m pip install --upgrade pip wheel
+          python -m pip install cython==0.29.34
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Install weather-tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,6 @@ jobs:
           activate-environment: weather-tools
       - name: Install weather-tools[test]
         run: |
-          pip install -e .[test] --use-deprecated=legacy-resolver
+          conda run -n weather-tools pip install -e .[test] --use-deprecated=legacy-resolver
       - name: Run type checker
-        run: pytype
+        run: conda run -n weather-tools pytype

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        python-version: ["3.8"]
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.7.0
@@ -98,28 +100,23 @@ jobs:
           access_token: ${{ github.token }}
         if: ${{github.ref != 'refs/head/main'}}
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: conda cache
+      uses: actions/cache@v2
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ hashFiles('ci3.8.yml') }}
+      - name: Setup conda environment
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.8"
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: "3.8"
-          conda-channels: anaconda, conda-forge
-      - name: Install ecCodes
-        run: |
-          conda install -y eccodes>=2.21.0 -c conda-forge
-          conda install -y pyproj -c conda-forge
-          conda install -y gdal -c conda-forge
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          python -m pip install --upgrade pip wheel
-          python -m pip install cython==0.29.34
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: Install weather-tools
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          environment-file: ci${{ matrix.python-version}}.yml
+          activate-environment: weather-tools
+      - name: Install weather-tools[test]
         run: |
           pip install -e .[test] --use-deprecated=legacy-resolver
       - name: Run type checker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,14 +101,14 @@ jobs:
         if: ${{github.ref != 'refs/head/main'}}
       - uses: actions/checkout@v2
       - name: conda cache
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
-        CACHE_NUMBER: 0
-      with:
-        path: ~/conda_pkgs_dir
-        key:
-          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ hashFiles('ci3.8.yml') }}
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ hashFiles('ci3.8.yml') }}
       - name: Setup conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -34,5 +34,6 @@ dependencies:
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
   - pip:
+    - cython==0.29.34
     - earthengine-api==0.1.329
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -34,5 +34,6 @@ dependencies:
   - xarray==2023.1.0
   - ruff==0.0.260
   - pip:
+    - cython==0.29.34
     - earthengine-api==0.1.329
     - .[test]

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - aria2=1.36.0
   - pip=22.3
   - pip:
+    - cython==0.29.34
     - earthengine-api==0.1.329
     - firebase-admin==6.0.1
     - .


### PR DESCRIPTION
Band-aid to issue #362.

Cython v3.0.0 released, which is breaking dependency installation.
