### PR TITLE
Weather-sp updated.

### DIFF
--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.3.1',
+    version='0.3.2',
     url='https://weather-tools.readthedocs.io/en/latest/weather_sp/',
     description='A tool to split weather data files into per-variable files.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
While splitting the `Grib` file using `weather-sp`, I noticed that the file names generated after the splitting did not match the expected format as shown [here](https://github.com/google/weather-tools/tree/main/weather_sp#output-template-with-python-style-formatting). Instead of providing the actual values for {0}, {1}, and so on, it was displaying `undef`. To resolve this issue, I made some modifications to the code, and now it is working correctly. I have thoroughly tested these changes both locally, and everything is functioning as expected.