### PR TITLE
`dl-v2` server queue client name bug

### DIFF
--- a/weather_dl_v2/fastapi-server/database/queue_handler.py
+++ b/weather_dl_v2/fastapi-server/database/queue_handler.py
@@ -60,7 +60,7 @@ class QueueHandler(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def _update_queue_client_name(
+    async def _update_client_name_in_license_queue(
         self, license_id: str, client_name: str
     ) -> None:
         pass
@@ -116,7 +116,7 @@ class QueueHandlerMock(QueueHandler):
             "Updated snapshot.id queue in 'queues' collection. Update_time: 00000."
         )
 
-    async def _update_queue_client_name(
+    async def _update_client_name_in_license_queue(
         self, license_id: str, client_name: str
     ) -> None:
         logger.info(
@@ -219,7 +219,7 @@ class QueueHandlerFirestore(QueueHandler):
             f"Updated {snapshot.id} queue in 'queues' collection. Update_time: {result.update_time}."
         )
 
-    async def _update_queue_client_name(
+    async def _update_client_name_in_license_queue(
         self, license_id: str, client_name: str
     ) -> None:
         result: WriteResult = (

--- a/weather_dl_v2/fastapi-server/database/queue_handler.py
+++ b/weather_dl_v2/fastapi-server/database/queue_handler.py
@@ -59,6 +59,12 @@ class QueueHandler(abc.ABC):
     ) -> None:
         pass
 
+    @abc.abstractmethod
+    async def _update_queue_client_name(
+        self, license_id: str, client_name: str
+    ) -> None:
+        pass
+
 
 class QueueHandlerMock(QueueHandler):
 
@@ -105,6 +111,13 @@ class QueueHandlerMock(QueueHandler):
 
     async def _update_config_priority_in_license(
         self, license_id: str, config_name: str, priority: int
+    ) -> None:
+        logger.info(
+            "Updated snapshot.id queue in 'queues' collection. Update_time: 00000."
+        )
+
+    async def _update_queue_client_name(
+        self, license_id: str, client_name: str
     ) -> None:
         logger.info(
             "Updated snapshot.id queue in 'queues' collection. Update_time: 00000."
@@ -204,4 +217,16 @@ class QueueHandlerFirestore(QueueHandler):
         )
         logger.info(
             f"Updated {snapshot.id} queue in 'queues' collection. Update_time: {result.update_time}."
+        )
+
+    async def _update_queue_client_name(
+        self, license_id: str, client_name: str
+    ) -> None:
+        result: WriteResult = (
+            await self.db.collection(self.collection)
+            .document(license_id)
+            .update({"client_name": client_name})
+        )
+        logger.info(
+            f"Updated {license_id} queue in 'queues' collection. Update_time: {result.update_time}."
         )

--- a/weather_dl_v2/fastapi-server/routers/license.py
+++ b/weather_dl_v2/fastapi-server/routers/license.py
@@ -104,6 +104,7 @@ async def update_license(
     license_id: str,
     license: License,
     license_handler: LicenseHandler = Depends(get_license_handler),
+    queue_handler: QueueHandler = Depends(get_queue_handler),
     create_deployment=Depends(get_create_deployment),
     terminate_license_deployment=Depends(get_terminate_license_deployment),
 ):
@@ -115,6 +116,9 @@ async def update_license(
 
     license_dict = license.dict()
     await license_handler._update_license(license_id, license_dict)
+    await queue_handler._update_queue_client_name(
+        license_id, license_dict["client_name"]
+    )
 
     terminate_license_deployment(license_id)
     await create_deployment(license_id, license_handler)

--- a/weather_dl_v2/fastapi-server/routers/license.py
+++ b/weather_dl_v2/fastapi-server/routers/license.py
@@ -116,7 +116,7 @@ async def update_license(
 
     license_dict = license.dict()
     await license_handler._update_license(license_id, license_dict)
-    await queue_handler._update_queue_client_name(
+    await queue_handler._update_client_name_in_license_queue(
         license_id, license_dict["client_name"]
     )
 


### PR DESCRIPTION
When updating license, if client_name is changed, same is not reflected in queue document for that license.