### PR TITLE
Not re-initializing ee if it's already initialized in the same worker.

### DIFF
--- a/weather_mv/loader_pipeline/ee.py
+++ b/weather_mv/loader_pipeline/ee.py
@@ -157,7 +157,12 @@ class SetupEarthEngine(RateLimit):
     def check_setup(self):
         """Ensures that setup has been called."""
         if not self._has_setup:
-            self.setup()
+            try:
+                # This throws an exception if ee is not initialized.
+                ee.data.getAlgorithms()
+                self._has_setup = True
+            except ee.EEException:
+                self.setup()
 
     def process(self, *args, **kwargs):
         """Checks that setup has been called then call the process implementation."""

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.18',
+    version='0.2.19',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
Earlier it was (re)initializing earthengine client upon every ingestion call, which in turn was calling ee highvolume api.

In beam dataflow, we essentially need to initialize earthengine only once in a device, not even a dataflow worker. These changes initializes ee only if necessary. Now it makes 50% less EE calls in filter and ingestion step.

Effect: Increases ingestion speed by roughly **100%**.