### PR TITLE
Fix : for a added feature in weather-mv to extract specific date's data from zarr files.

### DIFF
--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -104,8 +104,8 @@ class ToBigQuery(ToDataSink):
     skip_creating_polygon: bool = False
     lat_grid_resolution: t.Optional[float] = None
     lon_grid_resolution: t.Optional[float] = None
-    start_date: str = None
-    end_date: str = None
+    start_date: t.Optional[str] = None
+    end_date: t.Optional[str] = None
 
     @classmethod
     def add_parser_arguments(cls, subparser: argparse.ArgumentParser):

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -156,8 +156,10 @@ class ToBigQuery(ToDataSink):
         _, uri_extension = os.path.splitext(known_args.uris)
         if (uri_extension in ['.tif', '.tiff'] and not known_args.tif_metadata_for_start_time):
             raise RuntimeError("'--tif_metadata_for_start_time' is required for tif files.")
-        elif (uri_extension not in ['.tif', '.tiff'] and (known_args.tif_metadata_for_start_time
-                                                          or known_args.tif_metadata_for_end_time)):
+        elif uri_extension not in ['.tif', '.tiff'] and (
+            known_args.tif_metadata_for_start_time
+            or known_args.tif_metadata_for_end_time
+        ):
             raise RuntimeError("'--tif_metadata_for_start_time' and "
                                "'--tif_metadata_for_end_time' can be specified only for tif files.")
 
@@ -173,8 +175,8 @@ class ToBigQuery(ToDataSink):
         """Initializes Sink by creating a BigQuery table based on user input."""
         if self.zarr:
             self.xarray_open_dataset_kwargs = self.zarr_kwargs
-            self.start_date = self.zarr_kwargs.get('start_date', None)
-            self.end_date = self.zarr_kwargs.get('end_date', None)
+            self.start_date = self.zarr_kwargs.get('start_date')
+            self.end_date = self.zarr_kwargs.get('end_date')
         with open_dataset(self.first_uri, self.xarray_open_dataset_kwargs,
                           self.disable_grib_schema_normalization, self.tif_metadata_for_start_time,
                           self.tif_metadata_for_end_time, is_zarr=self.zarr) as open_ds:

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -146,8 +146,9 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
         raise ValueError('`--zarr_kwargs` argument is only allowed with valid Zarr input URI.')
 
     if known_args.zarr_kwargs:
-        if not known_args.zarr_kwargs['start_date'] or not known_args.zarr_kwargs['end_date']:
-            raise ValueError('`--zarr_kwargs` must be contains both `start_date` and `end_date`.')
+        if not known_args.zarr_kwargs.get('start_date') or not known_args.zarr_kwargs.get('end_date'):
+            logger.warning('`--zarr_kwargs` not contains both `start_date` and `end_date`'
+                           'so whole zarr-dataset will ingested.')
 
     if known_args.zarr:
         known_args.zarr_kwargs['chunks'] = known_args.zarr_kwargs.get('chunks', None)

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -145,6 +145,10 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
     if known_args.zarr_kwargs and not known_args.zarr:
         raise ValueError('`--zarr_kwargs` argument is only allowed with valid Zarr input URI.')
 
+    if known_args.zarr_kwargs:
+        if not known_args.zarr_kwargs['start_date'] or not known_args.zarr_kwargs['end_date']:
+            raise ValueError('`--zarr_kwargs` must be contains both `start_date` and `end_date`.')
+
     if known_args.zarr:
         known_args.zarr_kwargs['chunks'] = known_args.zarr_kwargs.get('chunks', None)
         known_args.zarr_kwargs['consolidated'] = known_args.zarr_kwargs.get('consolidated', True)

--- a/weather_mv/loader_pipeline/pipeline.py
+++ b/weather_mv/loader_pipeline/pipeline.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 import typing as t
+import warnings
 
 import apache_beam as beam
 from apache_beam.io.filesystems import FileSystems
@@ -147,8 +148,8 @@ def run(argv: t.List[str]) -> t.Tuple[argparse.Namespace, t.List[str]]:
 
     if known_args.zarr_kwargs:
         if not known_args.zarr_kwargs.get('start_date') or not known_args.zarr_kwargs.get('end_date'):
-            logger.warning('`--zarr_kwargs` not contains both `start_date` and `end_date`'
-                           'so whole zarr-dataset will ingested.')
+            warnings.warn('`--zarr_kwargs` not contains both `start_date` and `end_date`'
+                          'so whole zarr-dataset will ingested.')
 
     if known_args.zarr:
         known_args.zarr_kwargs['chunks'] = known_args.zarr_kwargs.get('chunks', None)


### PR DESCRIPTION
As mentioned in PR #396 I have added a feature in weather-mv which can allows users to access data for a specific date from zarr files but that is not working properly.

BQ ingestion of zarr data is done through the [`expand function`](https://github.com/google/weather-tools/blob/main/weather_mv/loader_pipeline/bq.py#L313) and in this function we can't get value of `start_date` and `end_date` from `xarray_open_dataset_kwargs` dict. So I added this code, using of we get the value of `start_date` & `end_date` from the `zarr_kwargs`.