### PR TITLE
Faster ingestion of Zarr into BQ by converting the chunk into pd.Dataframe

### DIFF
--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -205,6 +205,7 @@ weather-mv bq --uris "gs://your-bucket/*.grib" \
            --output_table $PROJECT.$DATASET_ID.$TABLE_ID \
            --xarray_open_dataset_kwargs '{"engine": "cfgrib", "indexpath": "", "backend_kwargs": {"filter_by_keys": {"typeOfLevel": "surface", "edition": 1}}}' \
            --temp_location "gs://$BUCKET/tmp" \
+           --input_chunks '{ "time": 1 }'
            --direct_num_workers 2
 ```
 

--- a/weather_mv/README.md
+++ b/weather_mv/README.md
@@ -205,7 +205,7 @@ weather-mv bq --uris "gs://your-bucket/*.grib" \
            --output_table $PROJECT.$DATASET_ID.$TABLE_ID \
            --xarray_open_dataset_kwargs '{"engine": "cfgrib", "indexpath": "", "backend_kwargs": {"filter_by_keys": {"typeOfLevel": "surface", "edition": 1}}}' \
            --temp_location "gs://$BUCKET/tmp" \
-           --input_chunks '{ "time": 1 }'
+           --input_chunks '{ "time": 1 }' \
            --direct_num_workers 2
 ```
 

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -331,7 +331,7 @@ class ToBigQuery(ToDataSink):
             yield row
 
     def chunks_to_rows(self, _, ds: xr.Dataset) -> t.Iterator[t.Dict]:
-        logger.info(f"Processing for time: {ds['time'].values} and level: {ds['level'].values}")
+        logger.info(f"Processing for time: {ds['time'].values}")
         uri = ds.attrs.get(DATA_URI_COLUMN, '')
         # Re-calculate import time for streaming extractions.
         if not self.import_time or self.zarr:

--- a/weather_mv/loader_pipeline/bq.py
+++ b/weather_mv/loader_pipeline/bq.py
@@ -310,7 +310,7 @@ class ToBigQuery(ToDataSink):
         first_time_step = to_json_serializable_type(first_ts_raw)
         for _, row in rows.iterrows():
             row = row.astype(object).where(pd.notnull(row), None)
-            row = {k: convert_time(v) for k, v in row.items()}
+            row = {k: to_json_serializable_type(v) for k, v in row.items()}
 
             # Add import metadata.
             row[DATA_IMPORT_TIME_COLUMN] = self.import_time
@@ -506,12 +506,3 @@ def get_lat_lon_range(value: float, lat_lon: str, is_point_out_of_bound: bool,
             return [-180 + lon_grid_resolution, 180 - lon_grid_resolution]
         else:
             return [value + lon_grid_resolution, value - lon_grid_resolution]
-
-def convert_time(val) -> t.Any:
-    """Converts pandas Timestamp values to ISO format."""
-    if isinstance(val, pd.Timestamp):
-        return val.replace(tzinfo=datetime.timezone.utc).isoformat()
-    elif isinstance(val, pd.Timedelta):
-        return val.total_seconds()
-    else:
-        return val

--- a/weather_mv/loader_pipeline/bq_test.py
+++ b/weather_mv/loader_pipeline/bq_test.py
@@ -205,7 +205,7 @@ class ExtractRowsTestBase(TestDataBase):
     def extract(self, data_path, *, variables=None, area=None, open_dataset_kwargs=None,
                 import_time=DEFAULT_IMPORT_TIME, disable_grib_schema_normalization=False,
                 tif_metadata_for_start_time=None, tif_metadata_for_end_time=None, zarr: bool = False, zarr_kwargs=None,
-                skip_creating_polygon: bool = False) -> t.Iterator[t.Dict]:
+                skip_creating_polygon: bool = False, input_chunks={ 'time': 1}) -> t.Iterator[t.Dict]:
         if zarr_kwargs is None:
             zarr_kwargs = {}
         op = ToBigQuery.from_kwargs(
@@ -215,7 +215,7 @@ class ExtractRowsTestBase(TestDataBase):
             tif_metadata_for_start_time=tif_metadata_for_start_time,
             tif_metadata_for_end_time=tif_metadata_for_end_time, skip_region_validation=True,
             disable_grib_schema_normalization=disable_grib_schema_normalization, coordinate_chunk_size=1000,
-            skip_creating_polygon=skip_creating_polygon)
+            skip_creating_polygon=skip_creating_polygon, input_chunks=input_chunks)
         coords = op.prepare_coordinates(data_path)
         for uri, chunk in coords:
             yield from op.extract_rows(uri, chunk)
@@ -792,6 +792,7 @@ class ExtractRowsFromZarrTest(ExtractRowsTestBase):
             variables=list(), area=list(), xarray_open_dataset_kwargs=dict(), import_time=None, infer_schema=False,
             tif_metadata_for_start_time=None, tif_metadata_for_end_time=None, skip_region_validation=True,
             disable_grib_schema_normalization=False,
+            input_chunks={'time': 1}
         )
 
         with TestPipeline() as p:

--- a/weather_mv/loader_pipeline/pipeline_test.py
+++ b/weather_mv/loader_pipeline/pipeline_test.py
@@ -69,6 +69,7 @@ class CLITests(unittest.TestCase):
             'log_level': 2,
             'use_local_code': False,
             'skip_creating_polygon': False,
+            'input_chunks': { 'time': 1 }
         }
 
 


### PR DESCRIPTION
We're having small chunks of a dataset while processing zarr in `weather-mv`. These changes will convert those chunks into `dataframe` and then extract rows directly from `dataframes`. As the chunk size in our control we can control the memory consumption during the pipeline.

Considerable Points
- Works with the `zarr` dataset for now.
- Will update for all types of dataset in future.
- Users can pass cli arguments to open datasets in the specified chunk scheme.
Example
```
--input_chunks '{ "time": 1, "level": 1 }'
```
Partially Solved: #414 