### PR TITLE
Fix CI/CD: Use libmamba while creating conda env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         channels: conda-forge
         environment-file: ci${{ matrix.python-version}}.yml
         activate-environment: weather-tools
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
         use-mamba: true
     - name: Check MetView's installation
       shell: bash -l {0}
@@ -117,6 +119,8 @@ jobs:
           channels: conda-forge
           environment-file: ci${{ matrix.python-version}}.yml
           activate-environment: weather-tools
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           use-mamba: true
       - name: Install weather-tools[test]
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         channels: conda-forge
         environment-file: ci${{ matrix.python-version}}.yml
         activate-environment: weather-tools
+        use-mamba: true
     - name: Check MetView's installation
       shell: bash -l {0}
       run: python -m metview selfcheck
@@ -116,6 +117,7 @@ jobs:
           channels: conda-forge
           environment-file: ci${{ matrix.python-version}}.yml
           activate-environment: weather-tools
+          use-mamba: true
       - name: Install weather-tools[test]
         run: |
           conda run -n weather-tools pip install -e .[test] --use-deprecated=legacy-resolver


### PR DESCRIPTION
Use libmamba for `conda` `env` creation.