### PR TITLE
Apply Aggregation Without Group By

### DIFF
--- a/xql/README.md
+++ b/xql/README.md
@@ -105,7 +105,7 @@ _Updated on 2024-01-08_
     2. [ ] On Variables 
 3. [x] **Aggregate Functions**: Only `AVG()`, `MIN()`, `MAX()`, `SUM()` are supported.
    1. [x] With Group By
-   2. [ ] Without Group By
+   2. [x] Without Group By
    3. [ ] Multiple Aggregate function in a single query
 4. [ ] **Order By**: Only suppoted for coordinates.
 5. [ ] **Limit**: Limiting the result to display.

--- a/xql/README.md
+++ b/xql/README.md
@@ -11,6 +11,7 @@ Running SQL like queries on Xarray Datasets. Consider dataset as a table and dat
 * **`aggregate` Functions** - Aggregate functions `AVG()`, `MIN()`, `MAX()`, etc. Only supported on data variables.
 * For more checkout the [road-map](https://github.com/google/weather-tools/tree/xql-init/xql#roadmap).
 > Note: For now, we support `where` conditions on coordinates only.
+> Note: For now, Only a single aggregate function is supported per query.
 
 # Quickstart
 

--- a/xql/main.py
+++ b/xql/main.py
@@ -275,7 +275,7 @@ def parse_query(query: str) -> xr.Dataset:
         mask = inorder(where, ds)
         ds = ds.where(mask, drop=True)
 
-    coord_to_squeeze = []
+    coord_to_squeeze = None
     if group_by:
         fields = [ e.args['this'].args['this'] for e in group_by.args['expressions'] ]
         coord_to_squeeze = get_coords_to_squeeze(fields, ds)


### PR DESCRIPTION
Now the aggregation works without a `group by` clause.
Queries like below are now supported.
```
SELECT
  MIN(temperature)
FROM 'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3'
WHERE
  time >= '2023-01-01' AND
  time < '2023-02-01'
```