### PR TITLE
Apply Multiple Aggregate function in a single query.

### DIFF
--- a/xql/README.md
+++ b/xql/README.md
@@ -77,9 +77,9 @@ python xql/main.py
         time >= '2022-01-01' AND 
         time < '2022-02-01' AND 
         latitude >= 66.5
-    GROUP BY time_day
+    GROUP BY time_date
     ```
-    Replace `time_day` to `time_month` or `time_year` if monthly or yearly average is needed. Also use `MIN()` and `MAX()` functions same way as `AVG()`.
+    Replace `time_date` to `time_month` or `time_year` if monthly or yearly average is needed. Also use `MIN()` and `MAX()` functions same way as `AVG()`.
 
 3. `caveat`: Above queries run on the client's local machine and it generates a large two dimensional array so querying for very large amount of data will fall into out of memory erros.
 

--- a/xql/README.md
+++ b/xql/README.md
@@ -12,8 +12,6 @@ Running SQL like queries on Xarray Datasets. Consider dataset as a table and dat
 * For more checkout the [road-map](https://github.com/google/weather-tools/tree/xql-init/xql#roadmap).
 > Note: For now, we support `where` conditions on coordinates only. 
 
-> Note: For now, variable with starting from the numbers(0-9) in aggregation function is not supported.
-
 # Quickstart
 
 ## Prerequisites
@@ -73,7 +71,7 @@ python xql/main.py
     ```
     ```
     SELECT 
-        AVG(temperature), SUM(charnock), MIN(temperature) 
+        AVG(temperature), SUM(charnock), MIN('100m_v_component_of_wind') 
     FROM era5
     WHERE 
         time >= '2022-01-01' AND 

--- a/xql/README.md
+++ b/xql/README.md
@@ -10,8 +10,9 @@ Running SQL like queries on Xarray Datasets. Consider dataset as a table and dat
 * **`group by` Functions** - This is supported on the coordinates only. e.g. time, latitude, longitude, etc.
 * **`aggregate` Functions** - Aggregate functions `AVG()`, `MIN()`, `MAX()`, etc. Only supported on data variables.
 * For more checkout the [road-map](https://github.com/google/weather-tools/tree/xql-init/xql#roadmap).
-> Note: For now, we support `where` conditions on coordinates only.
-> Note: For now, Only a single aggregate function is supported per query.
+> Note: For now, we support `where` conditions on coordinates only. 
+
+> Note: For now, variable with starting from the numbers(0-9) in aggregation function is not supported.
 
 # Quickstart
 
@@ -72,7 +73,7 @@ python xql/main.py
     ```
     ```
     SELECT 
-        AVG(temperature) 
+        AVG(temperature), SUM(charnock), MIN(temperature) 
     FROM era5
     WHERE 
         time >= '2022-01-01' AND 
@@ -107,7 +108,7 @@ _Updated on 2024-01-08_
 3. [x] **Aggregate Functions**: Only `AVG()`, `MIN()`, `MAX()`, `SUM()` are supported.
    1. [x] With Group By
    2. [x] Without Group By
-   3. [ ] Multiple Aggregate function in a single query
+   3. [x] Multiple Aggregate function in a single query
 4. [ ] **Order By**: Only suppoted for coordinates.
 5. [ ] **Limit**: Limiting the result to display.
 6. [ ] **Mathematical Operators** `(+, - , *, / )`: Add support to use mathematical operators in the query.

--- a/xql/main.py
+++ b/xql/main.py
@@ -231,7 +231,7 @@ def apply_group_by(time_fields: t.List[str], ds: xr.Dataset, agg_funcs: t.Dict[s
 
 def apply_aggregation(groups: t.Union[xr.Dataset, DatasetGroupBy], fun: str, dim: t.List[str] = []) -> xr.Dataset:
     """
-    Apply aggregation to the groups based` on the specified aggregation function.
+    Apply aggregation to the groups based on the specified aggregation function.
 
     Parameters:
     - groups (Union[xr.Dataset, xr.core.groupby.DatasetGroupBy]): The input dataset or dataset groupby object.

--- a/xql/main.py
+++ b/xql/main.py
@@ -261,8 +261,12 @@ def parse_query(query: str) -> xr.Dataset:
     group_by = expr.find(exp.Group)
 
     agg_funcs = [
-        { 'var': var.args['this'].args['this'].args['this'], 'func': var.key }
-        for var in expr.expressions if var.key in aggregate_function_map
+        {
+        'var': var.args['this'].args['this'].args['this'] if  var.args['this'].key == 'column'
+                                                        else var.args['this'].args['this'],
+        'func': var.key
+        }
+    for var in expr.expressions if var.key in aggregate_function_map
     ]
 
     if len(agg_funcs):

--- a/xql/main.py
+++ b/xql/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xql/main.py
+++ b/xql/main.py
@@ -255,7 +255,7 @@ def parse_query(query: str) -> xr.Dataset:
     if is_star is None:
         data_vars = [var.args['this'].args['this'] if var.key == 'column' else var.args['this']
              for var in expr.expressions
-             if (var.key == "column" or (var.key == "literal" and var.args.get("is_string") == True))]
+             if (var.key == "column" or (var.key == "literal" and var.args.get("is_string") is True))]
 
     where = expr.find(exp.Where)
     group_by = expr.find(exp.Group)

--- a/xql/main.py
+++ b/xql/main.py
@@ -195,8 +195,8 @@ def aggregate_variables(agg_funcs: t.List[t.Dict[str, str]],
             grouped_ds = grouped_ds.rename({"strftime": time_fields[0]})
 
         # Apply aggregation on dimensions
-        grouped_ds = apply_aggregation(grouped_ds, function, dims)
-        agg_dataset = agg_dataset.assign({f"{function}_{variable}": grouped_ds})
+        agg_dim_ds = apply_aggregation(grouped_ds, function, dims)
+        agg_dataset = agg_dataset.assign({f"{function}_{variable}": agg_dim_ds})
 
     return agg_dataset
 
@@ -229,7 +229,7 @@ def apply_group_by(time_fields: t.List[str], ds: xr.Dataset, agg_funcs: t.Dict[s
     return grouped_ds
 
 
-def apply_aggregation(groups: t.Union[xr.Dataset, DatasetGroupBy], fun: str, dim: t.List[str] = []) -> xr.Dataset:
+def apply_aggregation(groups: t.Union[xr.Dataset, DatasetGroupBy], fun: str, dim: t.List[str] = []) -> xr.DataArray:
     """
     Apply aggregation to the groups based on the specified aggregation function.
 


### PR DESCRIPTION
Added Support for the variable name with Quote in `SELECT Clause` and Multiple Aggregate functions in a single query.
Queries such as the following are now supported:

```
SELECT 
    SUM(charnock) , AVG(temperature), AVG(charnock) 
FROM 
    'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3' 
WHERE 
    time >= '2022-03-01' AND time < '2022-03-02' AND latitude < -66.5
```

```
SELECT 
    '100m_v_component_of_wind'  
FROM 
    'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3' 
WHERE 
    time >= '2022-03-01' AND time < '2022-03-02' AND latitude < -66.5
```