### PR TITLE
Dask Cluster Integration

### DIFF
--- a/xql/README.md
+++ b/xql/README.md
@@ -94,6 +94,28 @@ python xql/main.py
     FROM era5
     ```
 
+# Dask Cluster Configuration
+
+Steps to deploy a Dask Cluster on GKE.
+1. Create a Kubernetes cluster if don't have any. Follow [Creating a zonal cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster).
+2. Get Cluster Credentials on Local Machine
+    ```
+    gcloud container clusters get-credentials {cluster_name} --region {cluster_region} --project {project}
+    ```
+3. Install `helm`. Follow [Helm | Installing Helm](https://helm.sh/docs/intro/install/). 
+4. Deploy Dask Cluster using below `helm` commands.
+    ```
+    helm repo add dask https://helm.dask.org/
+    helm repo update
+    helm install xql-dask dask/dask
+    ```
+    > Replace `xql-dask` with the name you want your dask cluster to have. Just set `DASK_CLUSTER={dask_cluster_name}` environment variable.
+4. Connect to a dask cluster
+    ```
+    from xql.utils import connect_dask_cluster
+    connect_dask_cluster()
+    ```
+
 # Roadmap
 
 _Updated on 2024-01-08_

--- a/xql/README.md
+++ b/xql/README.md
@@ -109,7 +109,7 @@ Steps to deploy a Dask Cluster on GKE.
     helm repo update
     helm install xql-dask dask/dask
     ```
-    > Replace `xql-dask` with the name you want your dask cluster to have. Just set `DASK_CLUSTER={dask_cluster_name}` environment variable.
+    > Replace `xql-dask` from above command with the name you want your dask cluster to have. Just set `DASK_CLUSTER={dask_cluster_name}` environment variable.
 4. Connect to a dask cluster
     ```
     from xql.utils import connect_dask_cluster

--- a/xql/main.py
+++ b/xql/main.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from src.xql import main
+from src.xql.utils import connect_dask_cluster
 
 if __name__ == '__main__':
     try:
+        # Connect Dask Cluster
+        connect_dask_cluster()
         while True:
             query = input("xql> ")
             if query == ".exit":

--- a/xql/setup.py
+++ b/xql/setup.py
@@ -15,7 +15,19 @@
 
 from setuptools import find_packages, setup
 
-requirements = ["fsspec", "gcsfs", "numpy", "sqlglot", "xarray", "xee", "zarr"]
+requirements = [
+    "dask==2024.3.0",
+    "distributed==2024.3.0",
+    "dask_kubernetes",
+    "fsspec",
+    "gcsfs==2024.2.0",
+    "numpy==1.26.3",
+    "sqlglot",
+    "toolz==0.12.0",
+    "xarray==2024.01.0",
+    "xee",
+    "zarr==2.17.0"
+]
 
 setup(
     name="xql",

--- a/xql/src/xql/apply.py
+++ b/xql/src/xql/apply.py
@@ -432,28 +432,19 @@ def display_table_dataset_map(cmd: str) -> None:
         list_key_values(table_dataset_map)
 
 
-def display_result(result: t.Any, query: str) -> None:
-    """
-    Display the result of a query.
-
-    Args:
-        result (Any): The result to be displayed.
-    """
-    if isinstance(result, xr.Dataset):
-        df = filter_records(convert_to_dataframe(result), query)
-        print(df)
-    else:
-        print(result)
-
 @timing
-def run_query(query: str) -> None:
+def run_query(query: str, connect_cluster = True) -> None:
     """
     Run a query and display the result.
 
     Args:
         query (str): The query to be executed.
     """
-    result = parse_query(query)
+    try:
+        result = parse_query(query)
+    except Exception as e:
+        result = f"ERROR: {type(e).__name__}: {e.__str__()}."
+        return result
     return filter_records(convert_to_dataframe(result), query)
 
 @timing
@@ -471,9 +462,5 @@ def main(query: str):
         display_table_dataset_map(query)
 
     else:
-        try:
-            result = parse_query(query)
-        except Exception as e:
-            result = f"ERROR: {type(e).__name__}: {e.__str__()}."
-
-        display_result(result, query)
+        result = run_query(query)
+        print(result, query)

--- a/xql/src/xql/apply.py
+++ b/xql/src/xql/apply.py
@@ -433,7 +433,7 @@ def display_table_dataset_map(cmd: str) -> None:
 
 
 @timing
-def run_query(query: str, connect_cluster = True) -> None:
+def run_query(query: str) -> None:
     """
     Run a query and display the result.
 

--- a/xql/src/xql/utils.py
+++ b/xql/src/xql/utils.py
@@ -36,7 +36,7 @@ def connect_dask_cluster() -> None:
     """
     Connects to a Dask cluster.
     """
-    # Fetch the cluster name from environment variable, default to "era5-dask" if not set
+    # Fetch the cluster name from environment variable, default to "xql-dask" if not set
     cluster_name = os.getenv('DASK_CLUSTER', "xql-dask")
 
     try:

--- a/xql/src/xql/utils.py
+++ b/xql/src/xql/utils.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from dask_kubernetes import HelmCluster
+from dask.distributed import Client
 from functools import wraps
 from time import gmtime, strftime, time
 
@@ -26,3 +30,25 @@ def timing(f):
         print(f"Query took: { strftime('%H:%M:%S', gmtime(te - ts)) }")
         return result
     return wrap
+
+
+def connect_dask_cluster() -> None:
+    """
+    Connects to a Dask cluster.
+    """
+    # Fetch the cluster name from environment variable, default to "era5-dask" if not set
+    cluster_name = os.getenv('DASK_CLUSTER', "xql-dask")
+
+    try:
+        # Create a HelmCluster instance with the specified release name
+        cluster = HelmCluster(release_name=cluster_name)
+
+        # Connect a Dask client to the cluster
+        client = Client(cluster) # noqa: F841
+
+        # Print a message indicating successful connection
+        print("Dask cluster connected.")
+
+    except Exception:
+        # Print a message indicating failure to connect
+        print("Dask cluster not connected.")


### PR DESCRIPTION
- (Optional) Connect to the `Dask` cluster before starting the tool.

Steps to Use
---
- Deploy a `Dask` cluster on Google `Kubernetes` Engine.
- Set environment Variable `DASK_CLUSTER={dask_cluster_name}` As a default xql-dask will be used as a `Dask` cluster name.
- Cluster will be automatically connected when the `CLI`.