### PR TITLE
Added default accuracy in regrid.

### DIFF
--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -159,7 +159,7 @@ class RegridChunk(MapChunkAsFieldset):
             return tmpl
 
     def apply(self, key: xbeam.Key, fs: Fieldset) -> t.Tuple[xbeam.Key, Fieldset]:
-        return key, mv.regrid(data=fs, **self.regrid_kwargs)
+        return key, mv.regrid(data=fs, accuracy=12, **self.regrid_kwargs)
 
 
 @dataclasses.dataclass
@@ -265,7 +265,7 @@ class Regrid(ToDataSink):
 
                 logger.info(f'Regridding {uri!r}.')
                 fs = mv.bindings.Fieldset(path=local_grib)
-                fieldset = mv.regrid(data=fs, **self.regrid_kwargs)
+                fieldset = mv.regrid(data=fs, accuracy=12, **self.regrid_kwargs)
 
             with tempfile.NamedTemporaryFile() as src:
                 logger.info(f'Writing {self.target_from(uri)!r} to local disk.')

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.21',
+    version='0.2.22',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
By providing accuracy, we ensure that data is matching if it was fetched directly in the same grid. User can pass their accuracy as per data, but the data we are using normally has accuracy=12.

Story:
When we were regriding the HRES data from `Reduced gaussian grid` to `normal latlong` grid, we observed that this data has significant difference from the data if it was fetched from ECMWF directly in normal latlon. After the analysis and exploration, we figured out that by passing the `accuracy: 12` while regriding, the data matches up to a point that it is usable.