### PR TITLE
Fixed the version of conda in the docker-file of weather-tools.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ ARG py_version=3.8
 FROM apache/beam_python${py_version}_sdk:2.40.0 as beam_sdk
 FROM continuumio/miniconda3:latest
 
-# Update miniconda
-RUN conda update conda -y
-
 # Add the mamba solver for faster builds
 RUN conda install -n base conda-libmamba-solver
 RUN conda config --set solver libmamba


### PR DESCRIPTION
In the existing code while creating the `environment` of the `weather-tools` through docker image it is stuck in-between due to the latest version of the conda.
I fixed the conda version in the existing code so the above error will not come in future.

While creating the `environment` for `weather-tools` using the Docker image, the process was getting stuck due to issues with the updated version of conda. I've addressed this by specifying a fixed version of conda in the existing code. This change ensures that similar issues will not occur in the future.