### PR TITLE
Removed default accuracy in regrid.

### DIFF
--- a/weather_mv/loader_pipeline/regrid.py
+++ b/weather_mv/loader_pipeline/regrid.py
@@ -159,7 +159,7 @@ class RegridChunk(MapChunkAsFieldset):
             return tmpl
 
     def apply(self, key: xbeam.Key, fs: Fieldset) -> t.Tuple[xbeam.Key, Fieldset]:
-        return key, mv.regrid(data=fs, **{"accuracy": 12, **self.regrid_kwargs})
+        return key, mv.regrid(data=fs, **self.regrid_kwargs)
 
 
 @dataclasses.dataclass
@@ -266,7 +266,7 @@ class Regrid(ToDataSink):
 
                     logger.info(f'Regridding {uri!r}.')
                     fs = mv.bindings.Fieldset(path=local_grib)
-                    fieldset = mv.regrid(data=fs, **{"accuracy": 12, **self.regrid_kwargs})
+                    fieldset = mv.regrid(data=fs, **self.regrid_kwargs)
 
                 with tempfile.NamedTemporaryFile() as src:
                     logger.info(f'Writing {self.target_from(uri)!r} to local disk.')

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.27',
+    version='0.2.28',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
Removed default accuracy=12 changes from weather-mv regrid. This is to maintain the Metview's default behaviour. Metview takes accuracy of input data as default if user does not pass any accuracy.