### PR TITLE
Count element processing times in metrics properly & log each step time.

### DIFF
--- a/weather_mv/loader_pipeline/ee.py
+++ b/weather_mv/loader_pipeline/ee.py
@@ -252,6 +252,7 @@ class ToEarthEngine(ToDataSink):
     ingest_as_virtual_asset: bool
     use_deflate:bool
     use_metrics: bool
+    topic: str
 
     @classmethod
     def add_parser_arguments(cls, subparser: argparse.ArgumentParser):
@@ -362,7 +363,7 @@ class ToEarthEngine(ToDataSink):
                 band_names_dict = json.load(f)
 
         if self.use_metrics:
-            paths = paths | 'AddTimer' >> beam.ParDo(AddTimer())
+            paths = paths | 'AddTimer' >> beam.ParDo(AddTimer.from_kwargs(**vars(self)))
 
         if not self.dry_run:
             output = (

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -523,13 +523,13 @@ def get_file_time(element: t.Any) -> int:
     """Calculates element file's write timestamp in UTC."""
     try:
         element_parsed = urlparse(element)
-        if element_parsed.scheme == "gs":
+        if element_parsed.scheme == "gs":  # For file in Google cloud storage.
             client = storage.Client()
             bucket = client.get_bucket(element_parsed.netloc)
             blob = bucket.get_blob(element_parsed.path[1:])
 
             updated_time = int(blob.updated.timestamp())
-        else:
+        else:  # For file in local.
             file_stats = os.stat(element)
             updated_time = int(time.mktime(time.gmtime(file_stats.st_mtime)))
 

--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -26,6 +26,7 @@ import subprocess
 import tempfile
 import time
 import typing as t
+from urllib.parse import urlparse
 
 import apache_beam as beam
 import cfgrib
@@ -519,13 +520,13 @@ def open_dataset(uri: str,
 
 
 def get_file_time(element: t.Any) -> int:
+    """Calculates element file's write timestamp in UTC."""
     try:
-        if element.startswith("gs://"):
-            bucket_name, file_name = element[5:].split("/", 1)
-
+        element_parsed = urlparse(element)
+        if element_parsed.scheme == "gs":
             client = storage.Client()
-            bucket = client.get_bucket(bucket_name)
-            blob = bucket.get_blob(file_name)
+            bucket = client.get_bucket(element_parsed.netloc)
+            blob = bucket.get_blob(element_parsed.path[1:])
 
             updated_time = int(blob.updated.timestamp())
         else:

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.29',
+    version='0.2.30',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
Earlier, we were considering time taken to execute by each step and summing them to get the total time.
Now, we will consider timestamp at the last step - `IngestIntoEE` and timestamp at the first step when the file arrives in the bucket.

- `element_processing_time`: The total time that the pipeline has taken from when it arrived in the bucket to ingest it into EE. In the case of batch mode, it is from when it was picked by the pipeline to ingest it into EE.
- `data_latency_time`: The overall time for a file from file start_time (init time) to ingest it into EE.