### PR TITLE
Sample URLs of the cds is updated.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 env:
-  CDSAPI_URL: https://cds-beta.climate.copernicus.eu/api
+  CDSAPI_URL: https://cds.climate.copernicus.eu/api
   CDSAPI_KEY: 1234567-ab12-34cd-9876-4o4fake90909  # A fake key for testing
 jobs:
   build:

--- a/Configuration.md
+++ b/Configuration.md
@@ -217,7 +217,7 @@ source's catalog is structured.
 
 ### Copernicus / CDS
 
-**License**: By using Copernicus / CDS Dataset, users agree to the terms and conditions specified in [License](https://cds.climate.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf) document.
+**License**: By using Copernicus / CDS Dataset, users agree to the terms and conditions specified in dataset. i.e. [License](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=download#manage-licences).
 
 **Catalog**: [https://cds.climate.copernicus.eu/datasets](https://cds.climate.copernicus.eu/datasets)
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -219,10 +219,10 @@ source's catalog is structured.
 
 **License**: By using Copernicus / CDS Dataset, users agree to the terms and conditions specified in [License](https://cds.climate.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf) document.
 
-**Catalog**: [https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset](https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset)
+**Catalog**: [https://cds.climate.copernicus.eu/datasets](https://cds.climate.copernicus.eu/datasets)
 
 Visit the follow to register / acquire API credentials:
-_[Install the CDS API key](https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key)_. After, please set
+_[Install the CDS API key](https://cds.climate.copernicus.eu/how-to-api)_. After, please set
 the `api_url` and `api_key` arguments in the `parameters` section of your configuration. Alternatively, one can set
 these values as environment variables:
 
@@ -232,8 +232,8 @@ export CDSAPI_KEY=$api_key
 ```
 
 For CDS parameter options, check out
-the [Copernicus documentation](https://cds.climate.copernicus.eu/cdsapp#!/search?type=dataset).
-See [this example](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels?tab=form)
+the [Copernicus documentation](https://cds.climate.copernicus.eu/datasets).
+See [this example](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-pressure-levels?tab=overview)
 for what kind of requests one can make.
 
 ### MARS

--- a/README.md
+++ b/README.md
@@ -56,24 +56,26 @@ From here, you can use the `weather-*` tools from your python environment. Curre
 ## Quickstart
 
 In this tutorial, we will
-download the [Era 5 pressure level dataset](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels?tab=overview)
+download the [Era 5 pressure level dataset](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-pressure-levels?tab=overview)
 and ingest it into Google BigQuery using `weather-dl` and `weather-mv`, respectively.
 
 ### Prerequisites
 
-1. [Register](https://cds.climate.copernicus.eu/user/register) for a license from
+1. [Register here](https://www.ecmwf.int/) and [here](https://cds.climate.copernicus.eu/) for a license from
    ECMWF's [Copernicus (CDS) API](https://cds.climate.copernicus.eu/api-how-to).
-2. Install your license by copying your API url & key from [this page](https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key) to a new file `$HOME/.cdsapirc`.[^1] The file should look like this:
+
+2. User must agree to the Terms of Use of a dataset before downloading any data out of dataset.(i.e. accept [terms & condition](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=download#manage-licences) from here.)
+3. Install your license by copying your API url & key from [this page](https://cds.climate.copernicus.eu/how-to-api) to a new file `$HOME/.cdsapirc`.[^1] The file should look like this:
    ```
    url: https://cds.climate.copernicus.eu/api
    key: <YOUR_USER_ID>:<YOUR_API_KEY>
    ```
-3. If you do not already have a Google Cloud project, create one by following
+4. If you do not already have a Google Cloud project, create one by following
    [these steps](https://cloud.google.com/docs/get-started). If you are working on
    an existing project, make sure your user has the [BigQuery Admin role](https://cloud.google.com/bigquery/docs/access-control#bigquery.admin).
    To learn more about granting IAM roles to users in Google Cloud, visit the
    [official docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-4. Create an empty BigQuery Dataset. This can be done using
+5. Create an empty BigQuery Dataset. This can be done using
    the [Google Cloud Console](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-cloud-console#create_a_dataset)
    or via the [`bq` CLI tool](https://cloud.google.com/bigquery/docs/quickstarts/quickstart-command-line). 
    For example:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and ingest it into Google BigQuery using `weather-dl` and `weather-mv`, respecti
    ECMWF's [Copernicus (CDS) API](https://cds.climate.copernicus.eu/api-how-to).
 2. Install your license by copying your API url & key from [this page](https://cds.climate.copernicus.eu/api-how-to#install-the-cds-api-key) to a new file `$HOME/.cdsapirc`.[^1] The file should look like this:
    ```
-   url: https://cds.climate.copernicus.eu/api/v2
+   url: https://cds.climate.copernicus.eu/api
    key: <YOUR_USER_ID>:<YOUR_API_KEY>
    ```
 3. If you do not already have a Google Cloud project, create one by following

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ and ingest it into Google BigQuery using `weather-dl` and `weather-mv`, respecti
 
 1. [Register here](https://www.ecmwf.int/) and [here](https://cds.climate.copernicus.eu/) for a license from
    ECMWF's [Copernicus (CDS) API](https://cds.climate.copernicus.eu/api-how-to).
-
-2. User must agree to the Terms of Use of a dataset before downloading any data out of dataset.(i.e. accept [terms & condition](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=download#manage-licences) from here.)
+2. User must agree to the Terms of Use of a dataset before downloading any data out of dataset.(E.g.: accept [terms & condition](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=download#manage-licences) from here.)
 3. Install your license by copying your API url & key from [this page](https://cds.climate.copernicus.eu/how-to-api) to a new file `$HOME/.cdsapirc`.[^1] The file should look like this:
    ```
    url: https://cds.climate.copernicus.eu/api

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -38,4 +38,5 @@ dependencies:
     - earthengine-api==0.1.329
     - git+https://github.com/dabhicusp/cdsapi-beta-google-weather-tools.git@master#egg=cdsapi # TODO([#474](https://github.com/google/weather-tools/issues/474)): Compatible cdsapi with weather-dl.
     - google-cloud-monitoring
+    - pyparsing==3.1.4
     - .[test]

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -38,4 +38,5 @@ dependencies:
     - earthengine-api==0.1.329
     - git+https://github.com/dabhicusp/cdsapi-beta-google-weather-tools.git@master#egg=cdsapi # TODO([#474](https://github.com/google/weather-tools/issues/474)): Compatible cdsapi with weather-dl.
     - google-cloud-monitoring
+    - pyparsing==3.1.4
     - .[test]

--- a/configs/era5_example_config.cfg
+++ b/configs/era5_example_config.cfg
@@ -20,7 +20,7 @@ partition_keys=
     month
     day
     pressure_level
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/configs/multiple_multiple_licenses/era5_pressure500.cfg
+++ b/configs/multiple_multiple_licenses/era5_pressure500.cfg
@@ -21,15 +21,15 @@ partition_keys=
     day
     pressure_level
 [parameters.a]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [parameters.b]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [parameters.c]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/configs/multiple_multiple_licenses/era5_pressure600.cfg
+++ b/configs/multiple_multiple_licenses/era5_pressure600.cfg
@@ -21,15 +21,15 @@ partition_keys=
     day
     pressure_level
 [parameters.a]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [parameters.b]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [parameters.c]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/configs/multiple_multiple_licenses/era5_pressure700.cfg
+++ b/configs/multiple_multiple_licenses/era5_pressure700.cfg
@@ -21,15 +21,15 @@ partition_keys=
     day
     pressure_level
 [parameters.a]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [parameters.b]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [parameters.c]
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/configs/multiple_single_license/era5_pressure500.cfg
+++ b/configs/multiple_single_license/era5_pressure500.cfg
@@ -20,7 +20,7 @@ partition_keys=
     month
     day
     pressure_level
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/configs/multiple_single_license/era5_pressure600.cfg
+++ b/configs/multiple_single_license/era5_pressure600.cfg
@@ -20,7 +20,7 @@ partition_keys=
     month
     day
     pressure_level
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/configs/multiple_single_license/era5_pressure700.cfg
+++ b/configs/multiple_single_license/era5_pressure700.cfg
@@ -20,7 +20,7 @@ partition_keys=
     month
     day
     pressure_level
-api_url=https://cds.climate.copernicus.eu/api/v2
+api_url=https://cds.climate.copernicus.eu/api
 # a fake key for tests
 api_key=12345:1234567-ab12-34cd-9876-4o4fake90909
 [selection]

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
     - setuptools==70.3.0
     - git+https://github.com/dabhicusp/cdsapi-beta-google-weather-tools.git@master#egg=cdsapi # TODO([#474](https://github.com/google/weather-tools/issues/474)): Compatible cdsapi with weather-dl.
     - google-cloud-monitoring
+    - pyparsing==3.1.4
     - .
     - ./weather_dl
     - ./weather_mv

--- a/weather_dl/README.md
+++ b/weather_dl/README.md
@@ -125,7 +125,7 @@ For a full list of how to configure the Dataflow pipeline, please review
 You can view how your ECMWF API jobs are by visitng the client-specific job queue:
 
 * [MARS](https://apps.ecmwf.int/mars-activity/)
-* [Copernicus](https://cds.climate.copernicus.eu/live/queue)
+* [Copernicus](https://cds.climate.copernicus.eu/requests?tab=all)
 
 If you use Google Cloud Storage, we recommend using [`gsutil` (link)](https://cloud.google.com/storage/docs/gsutil) to
 inspect the progress of your downloads. For example:

--- a/weather_dl/download_pipeline/pipeline_test.py
+++ b/weather_dl/download_pipeline/pipeline_test.py
@@ -36,7 +36,7 @@ CONFIG = {
                    'partition_keys': ['year', 'month', 'day', 'pressure_level'],
                    'force_download': False,
                    'user_id': getpass.getuser(),
-                   'api_url': 'https://cds.climate.copernicus.eu/api/v2',
+                   'api_url': 'https://cds.climate.copernicus.eu/api',
                    'api_key': '12345:1234567-ab12-34cd-9876-4o4fake90909',  # fake key for testing.
                    },
     'selection': {'product_type': 'reanalysis',


### PR DESCRIPTION
Due to an update in the URL of the Climate Data Store (CDS) from `https://cds.climate.copernicus.eu/api/v2` to `https://cds.climate.copernicus.eu/api`, we need to update the URL in all relevant places.

Reference: https://cds.climate.copernicus.eu/how-to-api

This pull request (PR) will update the URLs from all of these places, ensuring that the code continues to function properly with the updated CDS URL.