### PR TITLE
Update attribute name to fix the non-acceptance of cli kwargs for earthengine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           channels: conda-forge
           environment-file: ci${{ matrix.python-version}}.yml
           activate-environment: weather-tools
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           use-mamba: true
       - name: Install weather-tools[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         channels: conda-forge
         environment-file: ci${{ matrix.python-version}}.yml
         activate-environment: weather-tools
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         use-mamba: true
     - name: Check MetView's installation

--- a/weather_mv/loader_pipeline/ee.py
+++ b/weather_mv/loader_pipeline/ee.py
@@ -461,13 +461,13 @@ class ConvertToAsset(beam.DoFn, KwargsFactoryMixin):
     Attributes:
         ee_asset_type: The type of asset to ingest in the earth engine. Default: IMAGE.
         asset_location: The bucket location at which asset files will be pushed.
-        open_dataset_kwargs: A dictionary of kwargs to pass to xr.open_dataset().
+        xarray_open_dataset_kwargs: A dictionary of kwargs to pass to xr.open_dataset().
         disable_grib_schema_normalization: A flag to turn grib schema normalization off; Default: on.
     """
 
     asset_location: str
     ee_asset_type: str = 'IMAGE'
-    open_dataset_kwargs: t.Optional[t.Dict] = None
+    xarray_open_dataset_kwargs: t.Optional[t.Dict] = None
     disable_grib_schema_normalization: bool = False
     group_common_hypercubes: t.Optional[bool] = False
     band_names_dict: t.Optional[t.Dict] = None
@@ -493,7 +493,7 @@ class ConvertToAsset(beam.DoFn, KwargsFactoryMixin):
         job_start_time = get_utc_timestamp()
 
         with open_dataset(uri,
-                          self.open_dataset_kwargs,
+                          self.xarray_open_dataset_kwargs,
                           self.disable_grib_schema_normalization,
                           initialization_time_regex=self.initialization_time_regex,
                           forecast_time_regex=self.forecast_time_regex,

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.32',
+    version='0.2.33',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
The current version of weather mover is unable pass the CLI xarray_open_dataset_kwargs argument to ConvertToAsset correctly.

As the ConvertToAsset is a dataclass, only the attributes defined in the class will be picked up from the kwargs provided via CLI while initialization (https://github.com/google/weather-tools/blob/main/weather_mv/loader_pipeline/sinks.py#L55). As the current attribute name is open_dataset_kwargs which doesn't match the argument provided from the CLI (xarray_open_dataset_kwargs), the xarray open dataset arguments are not being passed correctly. This PR fixes this issue.

Reference for removal of Mambaforge: https://github.com/conda-forge/miniforge/pull/704