### PR TITLE
update-version-actions/cache-v2-to-v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       if: ${{github.ref != 'refs/head/main'}}
     - uses: actions/checkout@v2
     - name: conda cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # Increase this value to reset cache if etc/example-environment.yml has not changed
         CACHE_NUMBER: 0
@@ -103,7 +103,7 @@ jobs:
         if: ${{github.ref != 'refs/head/main'}}
       - uses: actions/checkout@v2
       - name: conda cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed
           CACHE_NUMBER: 0


### PR DESCRIPTION
- update-version-actions/cache-v2-to-v3
- Updated version because it uses a deprecated version of actions/cache: v2
- https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down