### PR TITLE
Added Cloud monitoring version in environment dependencies.

### DIFF
--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -33,10 +33,10 @@ dependencies:
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
   - zarr=2.15.0
+  - google-cloud-monitoring==2.22.2
   - pip:
     - cython==0.29.34
     - earthengine-api==0.1.329
     - git+https://github.com/dabhicusp/cdsapi-beta-google-weather-tools.git@master#egg=cdsapi # TODO([#474](https://github.com/google/weather-tools/issues/474)): Compatible cdsapi with weather-dl.
-    - google-cloud-monitoring
     - pyparsing==3.1.4
     - .[test]

--- a/ci3.8.yml
+++ b/ci3.8.yml
@@ -33,7 +33,7 @@ dependencies:
   - google-cloud-sdk=410.0.0
   - aria2=1.36.0
   - zarr=2.15.0
-  - google-cloud-monitoring==2.22.2
+  - google-cloud-monitoring=2.22.2
   - pip:
     - cython==0.29.34
     - earthengine-api==0.1.329

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -33,7 +33,7 @@ dependencies:
   - xarray==2023.1.0
   - ruff==0.1.2
   - zarr=2.15.0
-  - google-cloud-monitoring==2.22.2
+  - google-cloud-monitoring=2.22.2
   - pip:
     - cython==0.29.34
     - earthengine-api==0.1.329

--- a/ci3.9.yml
+++ b/ci3.9.yml
@@ -33,10 +33,10 @@ dependencies:
   - xarray==2023.1.0
   - ruff==0.1.2
   - zarr=2.15.0
+  - google-cloud-monitoring==2.22.2
   - pip:
     - cython==0.29.34
     - earthengine-api==0.1.329
     - git+https://github.com/dabhicusp/cdsapi-beta-google-weather-tools.git@master#egg=cdsapi # TODO([#474](https://github.com/google/weather-tools/issues/474)): Compatible cdsapi with weather-dl.
-    - google-cloud-monitoring
     - pyparsing==3.1.4
     - .[test]

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - aria2=1.36.0
   - pip=22.3
   - zarr=2.15.0
-  - google-cloud-monitoring==2.22.2
+  - google-cloud-monitoring=2.22.2
   - pip:
     - cython==0.29.34
     - earthengine-api==0.1.329

--- a/environment.yml
+++ b/environment.yml
@@ -25,13 +25,13 @@ dependencies:
   - aria2=1.36.0
   - pip=22.3
   - zarr=2.15.0
+  - google-cloud-monitoring==2.22.2
   - pip:
     - cython==0.29.34
     - earthengine-api==0.1.329
     - firebase-admin==6.0.1
     - setuptools==70.3.0
     - git+https://github.com/dabhicusp/cdsapi-beta-google-weather-tools.git@master#egg=cdsapi # TODO([#474](https://github.com/google/weather-tools/issues/474)): Compatible cdsapi with weather-dl.
-    - google-cloud-monitoring
     - pyparsing==3.1.4
     - .
     - ./weather_dl


### PR DESCRIPTION
We use the `2.22.2` version of `google-cloud-monitoring` as the previous versions are not compatible with the monitoring changes.