### PR TITLE
Support added for year-month key

### DIFF
--- a/weather_dl/download_pipeline/parsers.py
+++ b/weather_dl/download_pipeline/parsers.py
@@ -23,6 +23,7 @@ import textwrap
 import typing as t
 import numpy as np
 from collections import OrderedDict
+from dateutil.relativedelta import relativedelta
 from urllib.parse import urlparse
 
 from .clients import CLIENTS
@@ -195,11 +196,14 @@ def _splitlines(block: str) -> t.List[str]:
     return [line.strip() for line in block.strip().splitlines()]
 
 
-def mars_range_value(token: str) -> t.Union[datetime.date, int, float]:
+def mars_range_value(token: str, key: str) -> t.Union[datetime.date, int, float]:
     """Converts a range token into either a date, int, or float."""
     # TODO(b/175432034): Recognize time values
     try:
-        return date(token)
+        if key == 'year-month':
+            return datetime.datetime.strptime(token, "%Y-%m").date()
+        else:
+            return date(token)
     except ValueError:
         pass
 
@@ -225,7 +229,7 @@ def mars_increment_value(token: str) -> t.Union[int, float]:
         raise ValueError("Token string must be an 'int' or a 'float'.")
 
 
-def parse_mars_syntax(block: str) -> t.List[str]:
+def parse_mars_syntax(block: str, key: str) -> t.List[str]:
     """Parses MARS list or range into a list of arguments; ranges are inclusive.
 
     Types for the range and value are inferred.
@@ -263,7 +267,7 @@ def parse_mars_syntax(block: str) -> t.List[str]:
         to_idx = tokens.index('to')
         assert to_idx != 0, "There must be a start token."
         start_token, end_token = tokens[to_idx - 1], tokens[to_idx + 1]
-        start, end = mars_range_value(start_token), mars_range_value(end_token)
+        start, end = mars_range_value(start_token, key), mars_range_value(end_token, key)
 
         # Parse increment token, or choose default increment.
         increment_token = '1'
@@ -275,7 +279,18 @@ def parse_mars_syntax(block: str) -> t.List[str]:
         raise SyntaxError(f"Improper range syntax in '{block}'.")
 
     # Return a range of values with appropriate data type.
-    if isinstance(start, datetime.date) and isinstance(end, datetime.date):
+    if key == 'year-month' and isinstance(start, datetime.date) and isinstance(end, datetime.date) and isinstance(increment, int):
+        result = []
+        offset = 1 if start <= end else -1
+        if increment >= 0:
+            increment *= offset # ensure increment has correct direction
+        current = start
+        while current <= end if offset > 0 else current >= end:
+            result.append(current.strftime("%Y-%m"))
+            current += relativedelta(months=increment)
+        return result
+    elif isinstance(start, datetime.date) and isinstance(end, datetime.date) and key != 'year-month':
+        increment *= -1 if start > end and increment > 0 else 1
         if not isinstance(increment, int):
             raise ValueError(
                 f"Increments on a date range must be integer number of days, '{increment_token}' is invalid."
@@ -311,7 +326,7 @@ def _parse_lists(config: dict, section: str = '') -> t.Dict:
             continue
 
         if '/' in val and 'parameters' not in section:
-            config[key] = parse_mars_syntax(val)
+            config[key] = parse_mars_syntax(val, key)
         elif '\n' in val:
             config[key] = _splitlines(val)
 

--- a/weather_dl/download_pipeline/parsers_test.py
+++ b/weather_dl/download_pipeline/parsers_test.py
@@ -518,6 +518,130 @@ class ParseConfigTest(unittest.TestCase):
             self._assert_no_newlines_in_section(actual)
             self.assertListEqual(actual['section']['list'], ['1', '2', '3', '4', '5'])
 
+
+    def test_json_parse_year_mon_one(self):
+        with io.StringIO('{"section": {"year-month": "2024-10/to/2024-10"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2024-10']
+            )
+
+
+    def test_json_parse_year_mon_one_by_one(self):
+        with io.StringIO('{"section": {"year-month": "2024-10/to/2024-10/by/1"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2024-10']
+            )
+
+
+    def test_json_parse_year_mon_one_by_two(self):
+        with io.StringIO('{"section": {"year-month": "2024-10/to/2024-10/by/2"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2024-10']
+            )
+
+
+    def test_json_parse_year_mon_six(self):
+        with io.StringIO('{"section": {"year-month": "2024-10/to/2025-3"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2024-10', '2024-11', '2024-12', '2025-01', '2025-02', '2025-03']
+            )
+
+
+    def test_json_parse_year_mon_six_by_one(self):
+        with io.StringIO('{"section": {"year-month": "2024-10/to/2025-3/by/1"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2024-10', '2024-11', '2024-12', '2025-01', '2025-02', '2025-03']
+            )
+
+
+    def test_json_parse_year_mon_six_by_three(self):
+        with io.StringIO('{"section": {"year-month": "2024-10/to/2025-3/by/3"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2024-10', '2025-01']
+            )
+
+
+    def test_json_parse_year_mon_six_rev(self):
+        with io.StringIO('{"section": {"year-month": "2025-3/to/2024-10"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2025-03', '2025-02', '2025-01', '2024-12', '2024-11', '2024-10']
+            )
+
+
+    def test_json_parse_year_mon_six_by_one_rev(self):
+        with io.StringIO('{"section": {"year-month": "2025-3/to/2024-10/by/-1"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2025-03', '2025-02', '2025-01', '2024-12', '2024-11', '2024-10']
+            )
+
+
+    def test_json_parse_year_mon_six_by_three_rev(self):
+        with io.StringIO('{"section": {"year-month": "2025-3/to/2024-10/by/-3"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2025-03', '2024-12']
+            )
+
+
+    def test_json_parse_year_mon_eighteen(self):
+        with io.StringIO('{"section": {"year-month": "2023-10/to/2025-3"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                [ '2023-10', '2023-11', '2023-12', '2024-01', '2024-02', '2024-03', '2024-04', '2024-05',
+                  '2024-06', '2024-07', '2024-08', '2024-09', '2024-10', '2024-11', '2024-12', '2025-01',
+                  '2025-02', '2025-03']
+            )
+
+
+    def test_json_parse_year_mon_eighteen_by_two(self):
+        with io.StringIO('{"section": {"year-month": "2023-10/to/2025-3/by/2"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                [ '2023-10', '2023-12', '2024-02', '2024-04', '2024-06', '2024-08', '2024-10', '2024-12',
+                  '2025-02']
+            )
+
+
+    def test_json_parse_year_mon_eighteen_by_six(self):
+        with io.StringIO('{"section": {"year-month": "2023-10/to/2025-3/by/6"}}') as f:
+            actual = parse_config(f)
+            self._assert_no_newlines_in_section(actual)
+            self.assertListEqual(
+                actual['section']['year-month'],
+                ['2023-10', '2024-04', '2024-10']
+            )
+
+
     def test_cfg_parses_parameter_subsections(self):
         with io.StringIO(
                 """


### PR DESCRIPTION
User can now specify [ year-month ] as a partition key.

Sample value can be,
`year-month=2024-10/to/2025-3`