### PR TITLE
Resolving multiple issues w.r.t. `GribSplitterV2`.

### DIFF
--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -29,7 +29,7 @@ _Common options_:
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
 * `--log-level`: An integer to configure log level. Default: 2(INFO).
 * `--use-local-code`: Supply local code to the Runner. Default: False.
-* `-w, --where`: Optional GRIB filter expression to apply during file splitting using grib_copy. This allows filtering GRIB messages based on key-value pairs, such as level, type of level, or date. Example: 'typeOfLevel=isobaricInhPa,level=1000'. More details can be found [here](https://confluence.ecmwf.int/display/ECC/grib_copy).
+* `-w, --where`: Optional GRIB filter expression to apply during file splitting using grib_copy. This allows filtering GRIB messages based on key-value pairs, such as level, type of level, or date. Example: 'typeOfLevel=isobaricInhPa,level=1000'. This flag is only applicable to GRIB files and is specifically supported by the GribSplitterV2 implementation. More details can be found [here](https://confluence.ecmwf.int/display/ECC/grib_copy).
 
 Invoke with `-h` or `--help` to see the full range of options.
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -29,7 +29,7 @@ _Common options_:
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
 * `--log-level`: An integer to configure log level. Default: 2(INFO).
 * `--use-local-code`: Supply local code to the Runner. Default: False.
-* `-w, --where`: Optional GRIB filter expression to apply during file splitting using grib_copy. This allows filtering GRIB messages based on key-value pairs, such as level, type of level, or date. Example: 'typeOfLevel=isobaricInhPa,level=1000'
+* `-w, --where`: Optional GRIB filter expression to apply during file splitting using grib_copy. This allows filtering GRIB messages based on key-value pairs, such as level, type of level, or date. Example: 'typeOfLevel=isobaricInhPa,level=1000'. More details can be found [here](https://confluence.ecmwf.int/display/ECC/grib_copy).
 
 Invoke with `-h` or `--help` to see the full range of options.
 

--- a/weather_sp/README.md
+++ b/weather_sp/README.md
@@ -29,6 +29,7 @@ _Common options_:
 * `-d, --dry-run`: Test the input file matching and the output file scheme without splitting.
 * `--log-level`: An integer to configure log level. Default: 2(INFO).
 * `--use-local-code`: Supply local code to the Runner. Default: False.
+* `-w, --where`: Optional GRIB filter expression to apply during file splitting using grib_copy. This allows filtering GRIB messages based on key-value pairs, such as level, type of level, or date. Example: 'typeOfLevel=isobaricInhPa,level=1000'
 
 Invoke with `-h` or `--help` to see the full range of options.
 
@@ -72,6 +73,18 @@ weather-sp --input-pattern 'gs://test-tmp/era5/2015/**' \
            --temp_location gs://$BUCKET/tmp  \
            --job_name $JOB_NAME \
            --use-local-code
+```
+
+Using DataflowRunner with using --where flag
+
+```bash
+weather-sp --input-pattern 'gs://test-tmp/2015/*.gb' \
+           --output-template 'gs://temp/domain_{domain}/class_{class}/stream_{stream}/expver_{expver}/levtype_{levtype}/date_{date}/time_{time}/step_{step}/{shortName}.gb' \
+           --runner DataflowRunner \
+           --project $PROJECT \
+           --temp_location gs://$BUCKET/tmp  \
+           --job_name $JOB_NAME \
+           --where "typeOfLevel=surface,shortName=lcc"
 ```
 
 Using ecCodes-powered grib splitting on Dataflow (this is often more robust, especially when splitting multiple 

--- a/weather_sp/setup.py
+++ b/weather_sp/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.3.2',
+    version='0.3.3',
     url='https://weather-tools.readthedocs.io/en/latest/weather_sp/',
     description='A tool to split weather data files into per-variable files.',
     install_requires=beam_gcp_requirements + base_requirements,

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -193,11 +193,11 @@ class GribSplitterV2(GribSplitter):
         split_dims_arg = ','.join(f'{dim}:s' for dim in split_dims)
         with self._copy_to_local_file() as local_file:
             self.logger.info('Skipping as needed...')
-            grib_get_args = [grib_get_cmd, '-p', split_dims_arg]
             # Append -w flag to filter GRIB messages matching the given expression
             if self.grib_filter_expression:
-                grib_get_args.extend(['-w', self.grib_filter_expression])
-            grib_get_args.append(local_file.name)
+                grib_get_args = [grib_get_cmd, '-p', split_dims_arg, '-w', self.grib_filter_expression, local_file.name]
+            else:
+                grib_get_args = [grib_get_cmd, '-p', split_dims_arg, local_file.name]
             grib_get_process = subprocess.Popen(grib_get_args, stdout=subprocess.PIPE)
             uniq_output = subprocess.check_output((uniq_cmd,), stdin=grib_get_process.stdout)
             output_paths = []

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -50,7 +50,8 @@ class FileSplitter(abc.ABC):
     """Base class for weather file splitters."""
 
     def __init__(self, input_path: str, output_info: OutFileInfo,
-                 force_split: bool = False, logging_level: int = logging.INFO, grib_filter_expression: str = None):
+                 force_split: bool = False, logging_level: int = logging.INFO,
+                 grib_filter_expression: t.Optional[str] = None):
         self.input_path = input_path
         self.output_info = output_info
         self.force_split = force_split

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -188,6 +188,8 @@ class GribSplitterV2(GribSplitter):
         delimiter = 'DELIMITER'
         flat_output_template = output_template.replace('/', delimiter)
         split_dims = self.output_info.split_dims()
+        # Construct a string where each split dimension is "dim:s".
+        # This ensures dims like time are represented as 0600 instead of 600.
         split_dims_arg = ','.join(f'{dim}:s' for dim in split_dims)
         with self._copy_to_local_file() as local_file:
             self.logger.info('Skipping as needed...')

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -193,8 +193,11 @@ class GribSplitterV2(GribSplitter):
         split_dims_arg = ','.join(f'{dim}:s' for dim in split_dims)
         with self._copy_to_local_file() as local_file:
             self.logger.info('Skipping as needed...')
-            grib_get_process = subprocess.Popen((grib_get_cmd, '-p', split_dims_arg, local_file.name),
-                                                stdout=subprocess.PIPE)
+            grib_get_args = [grib_get_cmd, '-p', split_dims_arg]
+            if self.grib_filter_expression:
+                grib_get_args.extend(['-w', self.grib_filter_expression])
+            grib_get_args.append(local_file.name)
+            grib_get_process = subprocess.Popen(grib_get_args, stdout=subprocess.PIPE)
             uniq_output = subprocess.check_output((uniq_cmd,), stdin=grib_get_process.stdout)
             output_paths = []
             skipped_paths = []

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -49,7 +49,7 @@ class FileSplitter(abc.ABC):
     """Base class for weather file splitters."""
 
     def __init__(self, input_path: str, output_info: OutFileInfo,
-                 force_split: bool = False, logging_level: int = logging.INFO):
+                 force_split: bool = False, logging_level: int = logging.INFO, grib_filter_expression: str = None):
         self.input_path = input_path
         self.output_info = output_info
         self.force_split = force_split
@@ -57,6 +57,7 @@ class FileSplitter(abc.ABC):
         self.logger.setLevel(logging_level)
         self.logger.debug('Splitter for path=%s, output base=%s',
                           self.input_path, self.output_info)
+        self.grib_filter_expression = grib_filter_expression
 
     @abc.abstractmethod
     def split_data(self) -> None:
@@ -197,6 +198,9 @@ class GribSplitterV2(GribSplitter):
             skipped_paths = []
             for line in uniq_output.decode('utf-8').rstrip('\n').split('\n'):
                 splits = dict(zip(split_dims, line.split(' ')))
+                # Ensure time values like '600' or '0' are zero-padded to 4 digits (e.g. '0600', '0000')
+                if 'time' in splits:
+                    splits['time'] = splits['time'].zfill(4)
                 output_path = self.output_info.formatted_output_path(splits)
                 if self.should_skip_file(output_path):
                     skipped_paths.append(output_path)
@@ -211,7 +215,13 @@ class GribSplitterV2(GribSplitter):
             with tempfile.TemporaryDirectory() as tmpdir:
                 self.logger.info('Performing split.')
                 dest = os.path.join(tmpdir, flat_output_template)
-                subprocess.run([grib_copy_cmd, local_file.name, dest], check=True)
+                if self.grib_filter_expression:
+                    subprocess.run([grib_copy_cmd, "-w",
+                                    self.grib_filter_expression,
+                                    local_file.name, dest], check=True)
+                else:
+                    subprocess.run([grib_copy_cmd, local_file.name, dest],
+                                   check=True)
 
                 self.logger.info('Uploading %r...', self.input_path)
                 for flat_target in os.listdir(tmpdir):
@@ -304,7 +314,8 @@ def get_splitter(file_path: str,
                  output_info: OutFileInfo,
                  dry_run: bool,
                  force_split: bool = False,
-                 logging_level: int = logging.INFO) -> FileSplitter:
+                 logging_level: int = logging.INFO,
+                 grib_filter_expression: str = None) -> FileSplitter:
     if dry_run:
         logger.info('Using splitter: DrySplitter')
         return DrySplitter(file_path, output_info, logging_level=logging_level)
@@ -321,10 +332,12 @@ def get_splitter(file_path: str,
         cmd = shutil.which('grib_copy')
         if cmd:
             logger.info('Using splitter: GribSplitterV2')
-            return GribSplitterV2(file_path, output_info, force_split, logging_level)
+            return GribSplitterV2(file_path, output_info, force_split,
+                                  logging_level, grib_filter_expression)
         else:
             logger.info('Using splitter: GribSplitter')
-            return GribSplitter(file_path, output_info, force_split, logging_level)
+            return GribSplitter(file_path, output_info, force_split,
+                                logging_level)
 
     # See the NetCDF Spec docs:
     # https://docs.unidata.ucar.edu/netcdf-c/current/faq.html#How-can-I-tell-which-format-a-netCDF-file-uses

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -194,6 +194,7 @@ class GribSplitterV2(GribSplitter):
         with self._copy_to_local_file() as local_file:
             self.logger.info('Skipping as needed...')
             grib_get_args = [grib_get_cmd, '-p', split_dims_arg]
+            # Append -w flag to filter GRIB messages matching the given expression
             if self.grib_filter_expression:
                 grib_get_args.extend(['-w', self.grib_filter_expression])
             grib_get_args.append(local_file.name)

--- a/weather_sp/splitter_pipeline/file_splitters.py
+++ b/weather_sp/splitter_pipeline/file_splitters.py
@@ -191,11 +191,10 @@ class GribSplitterV2(GribSplitter):
         with self._copy_to_local_file() as local_file:
             self.logger.info('Skipping as needed...')
             grib_fields = mv.read(local_file.name)
-            split_values = [tuple(mv.grib_get(grib_fields[i], split_dims)[0]) for i in range(len(grib_fields))]
-            uniq_output = list(dict.fromkeys(split_values))
+            split_values = mv.grib_get(grib_fields, split_dims)
             output_paths = []
             skipped_paths = []
-            for line in uniq_output:
+            for line in split_values:
                 splits = dict(zip(split_dims, line))
                 output_path = self.output_info.formatted_output_path(splits)
                 if self.should_skip_file(output_path):

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -21,6 +21,7 @@ import numpy as np
 import pygrib
 import pytest
 import xarray as xr
+from unittest.mock import patch
 
 import weather_sp
 from .file_name_utils import OutFileInfo
@@ -190,7 +191,8 @@ class TestGribSplitter:
         assert os.path.exists(f'{data_dir}/split_files/')
         assert splitter.should_skip()
 
-    def test_skips_existing_split_with_filter(self, data_dir):
+    @patch('weather_sp.splitter_pipeline.file_splitters.FileSplitter.should_skip_file')
+    def test_skips_existing_split_with_filter(self, mock_should_skip_file, data_dir):
         input_path = f'{data_dir}/era5_sample.grib'
         splitter = GribSplitterV2(
             input_path,
@@ -200,10 +202,8 @@ class TestGribSplitter:
                         template_folders=[]),
             grib_filter_expression="typeOfLevel=isobaricInhPa,level=200"
         )
-        assert not splitter.should_skip()
         splitter.split_data()
-        assert os.path.exists(f'{data_dir}/split_files/')
-        assert splitter.should_skip()
+        assert mock_should_skip_file.call_count == 8
 
     def test_does_not_skip__if_forced(self, data_dir, grib_splitter):
         input_path = f'{data_dir}/era5_sample.grib'

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -48,11 +48,6 @@ def grib_splitter(request):
     return request.param
 
 
-@pytest.fixture(params=[GribSplitterV2])
-def grib_splitter_v2(request):
-    return request.param
-
-
 class TestGetSplitter:
 
     def test_get_splitter_grib(self, data_dir):
@@ -111,10 +106,10 @@ class TestGribSplitter:
             {'typeOfLevel': 'surface', 'shortName': 'cc'})
         assert out == 'path/output/file.surface_cc.grib'
 
-    def test_split_data_with_filter(self, data_dir, grib_splitter_v2):
+    def test_split_data_with_filter(self, data_dir):
         input_path = f'{data_dir}/era5_sample.grib'
         output_base = f'{data_dir}/split_files/era5_sample'
-        splitter = grib_splitter_v2(
+        splitter = GribSplitterV2(
             input_path,
             OutFileInfo(
                 output_base,

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -48,6 +48,11 @@ def grib_splitter(request):
     return request.param
 
 
+@pytest.fixture(params=[GribSplitterV2])
+def grib_splitter_v2(request):
+    return request.param
+
+
 class TestGetSplitter:
 
     def test_get_splitter_grib(self, data_dir):
@@ -105,6 +110,42 @@ class TestGribSplitter:
         out = splitter.output_info.formatted_output_path(
             {'typeOfLevel': 'surface', 'shortName': 'cc'})
         assert out == 'path/output/file.surface_cc.grib'
+
+    def test_split_data_with_filter(self, data_dir, grib_splitter_v2):
+        input_path = f'{data_dir}/era5_sample.grib'
+        output_base = f'{data_dir}/split_files/era5_sample'
+        splitter = grib_splitter_v2(
+            input_path,
+            OutFileInfo(
+                output_base,
+                formatting='_{typeOfLevel}_{shortName}',
+                ending='.grib',
+                template_folders=[]),
+            grib_filter_expression="typeOfLevel=isobaricInhPa,level=200"
+        )
+        splitter.split_data()
+        assert os.path.exists(f'{data_dir}/split_files/') is True
+
+        short_names = ['d', 'cc', 'z', 'r']
+        input_data = defaultdict(list)
+        split_data = defaultdict(list)
+
+        input_grbs = pygrib.open(input_path)
+        for grb in input_grbs:
+            if grb.typeOfLevel == 'isobaricInhPa' and grb.level == 200:
+                input_data[grb.shortName].append(grb.values)
+
+        for sn in short_names:
+            split_file = f'{data_dir}/split_files/era5_sample_isobaricInhPa_{sn}.grib'
+            split_grbs = pygrib.open(split_file)
+            for grb in split_grbs:
+                split_data[sn].append(grb.values)
+
+        for sn in short_names:
+            orig = np.array(input_data[sn])
+            split = np.array(split_data[sn])
+            assert orig.shape == split.shape
+            np.testing.assert_allclose(orig, split)
 
     def test_split_data(self, data_dir, grib_splitter):
         input_path = f'{data_dir}/era5_sample.grib'

--- a/weather_sp/splitter_pipeline/file_splitters_test.py
+++ b/weather_sp/splitter_pipeline/file_splitters_test.py
@@ -190,6 +190,21 @@ class TestGribSplitter:
         assert os.path.exists(f'{data_dir}/split_files/')
         assert splitter.should_skip()
 
+    def test_skips_existing_split_with_filter(self, data_dir):
+        input_path = f'{data_dir}/era5_sample.grib'
+        splitter = GribSplitterV2(
+            input_path,
+            OutFileInfo(f'{data_dir}/split_files/era5_sample',
+                        formatting='_{typeOfLevel}_{shortName}',
+                        ending='.grib',
+                        template_folders=[]),
+            grib_filter_expression="typeOfLevel=isobaricInhPa,level=200"
+        )
+        assert not splitter.should_skip()
+        splitter.split_data()
+        assert os.path.exists(f'{data_dir}/split_files/')
+        assert splitter.should_skip()
+
     def test_does_not_skip__if_forced(self, data_dir, grib_splitter):
         input_path = f'{data_dir}/era5_sample.grib'
         output_base = f'{data_dir}/split_files/era5_sample'

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -42,9 +42,9 @@ def split_file(input_file: str,
                output_dir: t.Optional[str],
                formatting: str,
                dry_run: bool,
-               grib_filter_expression: t.Optional[str],
                force_split: bool = False,
-               logging_level: int = logging.INFO):
+               logging_level: int = logging.INFO,
+               grib_filter_expression: t.Optional[str] = None):
     output_base_name = get_output_base_name(input_path=input_file,
                                             input_base=input_base_dir,
                                             output_template=output_template,
@@ -128,6 +128,9 @@ def run(argv: t.List[str], save_main_session: bool = True):
                         'This allows filtering GRIB messages based on'
                         'key-value pairs, such as level, type of level,'
                         'or date.'
+                        'This flag is only applicable to GRIB files and is'
+                        'specifically supported by the GribSplitterV2'
+                        'implementation.'
                         'Example: typeOfLevel=isobaricInhPa,level=1000')
 
     known_args, pipeline_args = parser.parse_known_args(argv[1:])
@@ -171,7 +174,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
                                        output_dir,
                                        formatting,
                                        dry_run,
-                                       grib_filter_expression,
                                        known_args.force,
-                                       known_args.log_level)
+                                       known_args.log_level,
+                                       grib_filter_expression)
         )

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -42,6 +42,7 @@ def split_file(input_file: str,
                output_dir: t.Optional[str],
                formatting: str,
                dry_run: bool,
+               grib_filter_expression: t.Optional[str],
                force_split: bool = False,
                logging_level: int = logging.INFO):
     output_base_name = get_output_base_name(input_path=input_file,
@@ -57,7 +58,8 @@ def split_file(input_file: str,
                             output_base_name,
                             dry_run,
                             force_split,
-                            level)
+                            level,
+                            grib_filter_expression)
     splitter.split_data()
 
 
@@ -119,7 +121,15 @@ def run(argv: t.List[str], save_main_session: bool = True):
     parser.add_argument('-f', '--force', action='store_true', default=False,
                         help='Force re-splitting of the pipeline. Turns of skipping of already split data.')
     parser.add_argument('--log-level', type=int, default=2,
-                      help='An integer to configure log level. Default: 2(INFO)')
+                        help='An integer to configure log level. Default: 2(INFO)')
+    parser.add_argument('-w', '--where', default=None,
+                        help='Optional GRIB filter expression to apply during'
+                        'file splitting using grib_copy.'
+                        'This allows filtering GRIB messages based on'
+                        'key-value pairs, such as level, type of level,'
+                        'or date.'
+                        'Example: typeOfLevel=isobaricInhPa,level=1000')
+
     known_args, pipeline_args = parser.parse_known_args(argv[1:])
 
     configure_logger(known_args.log_level)  # 0 = error, 1 = warn, 2 = info, 3 = debug
@@ -132,6 +142,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
     output_dir = known_args.output_dir
     formatting = known_args.formatting
     dry_run = known_args.dry_run
+    grib_filter_expression = known_args.where
 
     if not output_template and not output_dir:
         raise ValueError('No output specified')
@@ -160,6 +171,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
                                        output_dir,
                                        formatting,
                                        dry_run,
+                                       grib_filter_expression,
                                        known_args.force,
                                        known_args.log_level)
         )

--- a/weather_sp/splitter_pipeline/pipeline.py
+++ b/weather_sp/splitter_pipeline/pipeline.py
@@ -122,7 +122,7 @@ def run(argv: t.List[str], save_main_session: bool = True):
                         help='Force re-splitting of the pipeline. Turns of skipping of already split data.')
     parser.add_argument('--log-level', type=int, default=2,
                         help='An integer to configure log level. Default: 2(INFO)')
-    parser.add_argument('-w', '--where', default=None,
+    parser.add_argument('-w', '--where', type=str, default=None,
                         help='Optional GRIB filter expression to apply during'
                         'file splitting using grib_copy.'
                         'This allows filtering GRIB messages based on'

--- a/weather_sp/splitter_pipeline/pipeline_test.py
+++ b/weather_sp/splitter_pipeline/pipeline_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 from .file_name_utils import OutFileInfo
 from .pipeline import _get_base_input_directory
@@ -60,6 +60,28 @@ class PipelineTest(unittest.TestCase):
                                                          ending='',
                                                          template_folders=[]),
                                              True)
+
+    @patch('weather_sp.splitter_pipeline.pipeline.get_splitter')
+    def test_split_file_with_filter(self, mock_get_splitter):
+        split_file(
+            input_file='somewhere/somefile',
+            input_base_dir='somewhere',
+            output_dir='out/there',
+            output_template=None,
+            formatting='_{variable}',
+            dry_run=True,
+            grib_filter_expression='typeOfLevel=isobaricInhPa,level=200',
+        )
+        mock_get_splitter.assert_called_with(
+            'somewhere/somefile',
+            OutFileInfo('out/there/somefile',
+                        formatting='_{variable}',
+                        ending='',
+                        template_folders=[]),
+            True,
+            False,
+            ANY,
+            'typeOfLevel=isobaricInhPa,level=200')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolve time padding and multiple type support in weather-splitter - specifically supported by the `GribSplitterV2` implementation:
- Ensure time values like '600' or '0' are zero-padded to 4 digits (e.g., '0600', '0000').
- Add support for handling multiple types of values within a single Grib file such as different levels (e.g. surface and pressure levels) within a single Grib file.