### PR TITLE
Reposition the decompressed file pointer to the start.

### DIFF
--- a/weather_mv/loader_pipeline/sinks.py
+++ b/weather_mv/loader_pipeline/sinks.py
@@ -422,6 +422,7 @@ def open_local(uri: str) -> t.Iterator[str]:
         with tempfile.NamedTemporaryFile() as dest_uncompressed:
             with CompressedFile(open(dest_file.name, 'rb'), compression_type=compression_type) as dcomp:
                 shutil.copyfileobj(dcomp, dest_uncompressed, DEFAULT_READ_BUFFER_SIZE)
+                dest_uncompressed.seek(0)  # Reposition the file pointer to the start.
                 yield dest_uncompressed.name
 
 

--- a/weather_mv/setup.py
+++ b/weather_mv/setup.py
@@ -65,7 +65,7 @@ setup(
     packages=find_packages(),
     author='Anthromets',
     author_email='anthromets-ecmwf@google.com',
-    version='0.2.37',
+    version='0.2.38',
     url='https://weather-tools.readthedocs.io/en/latest/weather_mv/',
     description='A tool to load weather data into BigQuery.',
     install_requires=beam_gcp_requirements + base_requirements,


### PR DESCRIPTION
- Sometimes when regriding some `.bz2` files they are flagged as corrupted. 
- When skipping the corrupt file check the regrid process fails with a *Segmentation fault*.
- However they are not corrupted but instead their pointer gets shifted after decompressing them in `open_local`.

These changes will help in repositioning the file pointer to the start of the file so that is gets processed properly.