### PR TITLE
Fix #243: Comment out 'prune test_data' in MANIFEST.in to suppress un…

### DIFF
--- a/weather_sp/MANIFEST.in
+++ b/weather_sp/MANIFEST.in
@@ -1,3 +1,4 @@
 global-exclude *_test.py
 include README.md
-prune test_data
+# Removing this line to fix the warning message issue #243
+# prune test_data


### PR DESCRIPTION
Hi @alxmrs ,
Fixed the unnecessary log in weather-sp by commenting out the prune test_data line in MANIFEST.in. Change is here:
https://github.com/pvrraju/weather-tools/tree/fix-unnecessary-log-message

can you see the PR once.